### PR TITLE
Fix fetching changes via Depends-On

### DIFF
--- a/new.php
+++ b/new.php
@@ -81,29 +81,35 @@ foreach ( $patches as &$patch ) {
 		__DIR__ . '/applypatch.sh'
 	];
 
+	$relatedChanges = [];
+	$relatedChanges[] = [ $data[0]['_number'], $data[0]['revisions'][$hash]['_number'] ];
+
 	// Look at all commits in this patch's tree for cross-repo dependencies to add
 	$url = "https://gerrit.wikimedia.org/r/changes/{$data[0]['id']}/revisions/$hash/related";
 	echo "<pre>$url</pre>";
 	$resp = file_get_contents( $url );
 	$data = json_decode( substr( $resp, 4 ), true );
-	$query = [];
 	// Ancestor commits only, not descendants
 	$foundCurr = false;
 	foreach ( $data['changes'] as $change ) {
-		$foundCurr = $foundCurr || $change['commit']['commit'] === $hash;
 		if ( $foundCurr ) {
 			// Querying by change number is allegedly deprecated, but the /related API doesn't return the 'id'
-			$url = "https://gerrit.wikimedia.org/r/changes/{$change['_change_number']}/revisions/{$change['_revision_number']}/commit";
-			echo "<pre>$url</pre>";
-			$resp = file_get_contents( $url );
-			$data = json_decode( substr( $resp, 4 ), true );
+			$relatedChanges[] = [ $change['_change_number'], $change['_revision_number'] ];
+		}
+		$foundCurr = $foundCurr || $change['commit']['commit'] === $hash;
+	}
 
-			preg_match_all( '/^Depends-On: (.+)$/m', $data['message'], $m );
-			foreach ( $m[1] as $changeid ) {
-				if ( !in_array( $changeid, $patches, true ) ) {
-					// The entry we add here will be processed by the topmost foreach
-					$patches[] = $changeid;
-				}
+	foreach ( $relatedChanges as [ $id, $rev ] ) {
+		$url = "https://gerrit.wikimedia.org/r/changes/$id/revisions/$rev/commit";
+		echo "<pre>$url</pre>";
+		$resp = file_get_contents( $url );
+		$data = json_decode( substr( $resp, 4 ), true );
+
+		preg_match_all( '/^Depends-On: (.+)$/m', $data['message'], $m );
+		foreach ( $m[1] as $changeid ) {
+			if ( !in_array( $changeid, $patches, true ) ) {
+				// The entry we add here will be processed by the topmost foreach
+				$patches[] = $changeid;
 			}
 		}
 	}


### PR DESCRIPTION
The '/related' endpoint returns nothing if the change has no related
changes, so we weren't parsing Depends-On in changes that didn't have
direct dependencies.