### PR TITLE
Allow trusted users to create patches without V+2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"require": {
-		"mediawiki/oauthclient": "1.1.0"
+		"mediawiki/oauthclient": "1.1.0",
+		"symfony/yaml": "^5.1"
 	},
 	"require-dev": {
 		"jakub-onderka/php-parallel-lint": "1.0.0",


### PR DESCRIPTION
Use the V+2 check first because that is quicker, but if it
fails check the uploader's email against the trusted user
whitelist.

Fixes #51