### PR TITLE
Query patch metadata first when creating

### DIFF
--- a/new.php
+++ b/new.php
@@ -30,17 +30,6 @@ if ( $patches ) {
 	$patches = [];
 }
 
-echo "Updating repositories...";
-
-$cmd = make_shell_command( [
-	'PATCHDEMO' => __DIR__,
-], __DIR__ . '/updaterepos.sh' );
-
-$error = shell_echo( $cmd );
-if ( $error ) {
-	abandon( "Could not update repositories." );
-}
-
 echo "Querying patch metadata...";
 
 $patchesApplied = [];
@@ -177,6 +166,17 @@ $baseEnv = [
 	'PATCHDEMO' => __DIR__,
 	'NAME' => $namePath,
 ];
+
+echo "Updating repositories...";
+
+$cmd = make_shell_command( [
+	'PATCHDEMO' => __DIR__,
+], __DIR__ . '/updaterepos.sh' );
+
+$error = shell_echo( $cmd );
+if ( $error ) {
+	abandon( "Could not update repositories." );
+}
 
 echo "Creating your wiki...";
 


### PR DESCRIPTION
The mostly likely failure scenario is that the user inputted patches that can't be merged, so do this first so the error (1) displays sooner and (2) is shown at the top of the page.