### PR TITLE
Fix the Cron job to deduplicate files

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -28,8 +28,8 @@ composer update --no-dev
 npm install --production
 
 # setup daily cron job to deduplicate files
-BASEDIR=$(dirname "$0")
-sudo ln -s $BASEDIR/deduplicate.sh /etc/cron.daily/
+echo $(readlink -f deduplicate.sh) > /etc/cron.daily/patchdemo-deduplicate
+chmod u+x /etc/cron.daily/patchdemo-deduplicate
 
 # set session expiration to a month (default is 24 minutes???), cookie expiration too
 echo "session.gc_maxlifetime = 2592000

--- a/setup.sh
+++ b/setup.sh
@@ -28,7 +28,8 @@ composer update --no-dev
 npm install --production
 
 # setup daily cron job to deduplicate files
-echo $(readlink -f deduplicate.sh) > /etc/cron.daily/patchdemo-deduplicate
+echo "#!/bin/bash
+$(readlink -f deduplicate.sh)" > /etc/cron.daily/patchdemo-deduplicate
 chmod u+x /etc/cron.daily/patchdemo-deduplicate
 
 # set session expiration to a month (default is 24 minutes???), cookie expiration too


### PR DESCRIPTION
The script was not executed, because it did not pass the "sanity
checks": https://stackoverflow.com/a/43454485

>   the files under these directories have to be pass some sanity checks
>   including the following: be executable, be owned by root, not be
>   writable by group or other and, if symlinks, point to files owned by
>   root. Additionally, the file names must conform to the filename
>   requirements of run-parts: they must be entirely made up of letters,
>   digits and can only contain the special signs underscores ('_') and
>   hyphens ('-'). Any file that does not conform to these requirements
>   will not be executed by run-parts. For example, any file containing
>   dots will be ignored.

Furthermore, because it was a symlink, the actual script would not
correctly detect the directory it was in.

Simplify things by making a regular script that call outs script
instead of a symlink.