### PR TITLE
Revert "Run update script after installation"

### DIFF
--- a/createwiki.sh
+++ b/createwiki.sh
@@ -58,9 +58,6 @@ cat $PATCHDEMO/LocalSettings.txt >> $PATCHDEMO/wikis/$NAME/w/LocalSettings.php
 sleep 1 # Ensure edit appears after creation in history
 echo "$MAINPAGE" | php $PATCHDEMO/wikis/$NAME/w/maintenance/edit.php "Main_Page"
 
-# run update script (#166)
-php $PATCHDEMO/wikis/$NAME/w/maintenance/update.php --quick
-
 # grant FlaggedRevs editor rights to the default account
 if [ -d $PATCHDEMO/wikis/$NAME/w/extensions/FlaggedRevs ]; then
 	php $PATCHDEMO/wikis/$NAME/w/maintenance/createAndPromote.php "Patch Demo" --force --custom-groups editor


### PR DESCRIPTION
Reverts #168. The MediaWiki bug https://phabricator.wikimedia.org/T266681 is fixed and this should no longer be needed.