### PR TITLE
Use htmlentities when escaping link label

### DIFF
--- a/new.php
+++ b/new.php
@@ -205,6 +205,8 @@ foreach ( $patchesApplied as $patch ) {
 		get_linked_tasks( $data['message'], $linkedTasks );
 	}
 
+	$t = htmlentities( $t );
+
 	$mainPage .= "\n:* [{$config['gerritUrl']}/r/c/$r/$p <nowiki>$t</nowiki>]";
 }
 


### PR DESCRIPTION
Fixes #210