### PR TITLE
Announce when wikis are deleted

### DIFF
--- a/includes.php
+++ b/includes.php
@@ -93,7 +93,7 @@ function wiki_add_announced_tasks( string $wiki, array $announcedTasks ) {
 	global $mysqli;
 	$stmt = $mysqli->prepare( 'UPDATE wikis SET announcedTasks = ? WHERE wiki = ?' );
 	$announcedTasks = json_encode( $announcedTasks );
-	$stmt->bind_param( 'ss', $accouncedTasks, $wiki );
+	$stmt->bind_param( 'ss', $announcedTasks, $wiki );
 	$stmt->execute();
 	$stmt->close();
 }

--- a/new.php
+++ b/new.php
@@ -301,23 +301,16 @@ foreach ( $commands as $i => $command ) {
 	}
 }
 
-if ( $announce && count( $linkedTasks ) && $config['conduitApiKey'] ) {
+if ( $announce && count( $linkedTasks ) ) {
 	set_progress( 95, 'Posting to Phabricator...' );
-	$api = new \Phabricator\Phabricator( $config['phabricatorUrl'], $config['conduitApiKey'] );
 
 	foreach ( $linkedTasks as $task ) {
-		$api->Maniphest( 'edit', [
-			'objectIdentifier' => 'T' . $task,
-			'transactions' => [
-				[
-					'type' => 'comment',
-					'value' =>
-						"Test wiki created on [[ $server$serverPath | Patch Demo ]]" . ( $user ? ' by ' . $user->username : '' ) . " using patch(es) linked to this task:\n" .
-						"\n" .
-						"$server$serverPath/wikis/$namePath/w/"
-				]
-			]
-		] );
+		post_phab_comment(
+			'T' . $task,
+			"Test wiki **created** on [[ $server$serverPath | Patch Demo ]]" . ( $creator ? ' by ' . $creator : '' ) . " using patch(es) linked to this task:\n" .
+			"\n" .
+			"$server$serverPath/wikis/$namePath/w/"
+		);
 	}
 	wiki_add_announced_tasks( $namePath, $linkedTasks );
 }


### PR DESCRIPTION
Uses the 'announcedTasks' db column to ensure we only
announce on tasks that got the creation announcement.

Fixes #188