### PR TITLE
[config] set $wgGlobalWatchlistDevMode to true

### DIFF
--- a/LocalSettings.txt
+++ b/LocalSettings.txt
@@ -52,6 +52,9 @@ $wgCitoidFullRestbaseURL = 'https://www.mediawiki.org/api/rest_';
 $wgLocaltimezone = 'UTC';
 $wgFragmentMode = [ 'html5', 'legacy' ];
 
+// GlobalWatchlist
+$wgGlobalWatchlistDevMode = true;
+
 // InstantCommons
 $wgUseInstantCommons = true;
 


### PR DESCRIPTION
No longer the default following [1], but would be helpful on patchdemo. Results in extra information being sent to the console log.

[1] https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/GlobalWatchlist/+/17ba0e3315e1d48215c885f065fedb503f454404