### PR TITLE
editcounts: Don't error if DB not found

### DIFF
--- a/editcounts.php
+++ b/editcounts.php
@@ -29,9 +29,6 @@ while ( $data = $results->fetch_assoc() ) {
 	foreach ( $mysqli->query( "SELECT * FROM patchdemo_$wiki.site_stats LIMIT 1" ) as $row ) {
 		$wikis[$wiki] += $row;
 	}
-	if ( $mysqli->error ) {
-		die( $mysqli->error );
-	}
 }
 
 uksort( $wikis, function ( $a, $b ) use ( $wikis ) {


### PR DESCRIPTION
We already handle missing data in the table, and the
DB might not exist if the wiki didn't setup correctly.
