### PR TITLE
Fix authentication functions for private installs

### DIFF
--- a/config.default.php
+++ b/config.default.php
@@ -4,8 +4,6 @@ $config = [
 	'gerritUrl' => 'https://gerrit.wikimedia.org',
 	// Message shown below the main form (allows HTML formatting)
 	'banner' => '',
-	// Allow any user to delete wikis, e.g. on a private installation
-	'allowDelete' => false,
 	// Require that patches are V+2 before building the wiki
 	'requireVerified' => true,
 	// OAuth config. When enabled only authenticated users can create

--- a/includes.php
+++ b/includes.php
@@ -392,21 +392,25 @@ function get_branches( $repo ) {
 }
 
 function can_delete( $creator = null ) {
-	global $config, $user;
+	global $config, $user, $useOAuth;
+	if ( !$useOAuth ) {
+		// Unauthenticated site
+		return true;
+	}
 	$username = $user ? $user->username : null;
-	$admins = $config[ 'oauth' ] ? $config[ 'oauth' ][ 'admins' ] : [];
-	return $config[ 'allowDelete' ] || ( $username && $username === $creator ) || can_admin();
+	$admins = $useOAuth ? $config[ 'oauth' ][ 'admins' ] : [];
+	return ( $username && $username === $creator ) || can_admin();
 }
 
 function can_admin() {
-	global $config, $user;
-	if ( $config[ 'oauth'] ) {
-		$username = $user ? $user->username : null;
-		$admins = $config[ 'oauth' ] ? $config[ 'oauth' ][ 'admins' ] : [];
-		return $username && in_array( $username, $admins, true );
+	global $config, $user, $useOAuth;
+	if ( !$useOAuth ) {
+		// Unauthenticated site
+		return true;
 	}
-	// Unauthenticated site, anyone can admin
-	return true;
+	$username = $user ? $user->username : null;
+	$admins = $config[ 'oauth' ][ 'admins' ];
+	return $username && in_array( $username, $admins, true );
 }
 
 function user_link( $username ) {


### PR DESCRIPTION
Doesn't make sense to have any restrictions on a
private installation. Just allow all users to do
everything.
