### PR TITLE
Allow use of the Mobilefrontend content provider proxy

### DIFF
--- a/LocalSettings-proxy.txt
+++ b/LocalSettings-proxy.txt
@@ -1,0 +1,5 @@
+// Allow proxying content from production
+
+$wgMFContentProviderClass = "MobileFrontend\\ContentProviders\\MwApiContentProvider";
+$wgMFContentProviderTryLocalContentFirst = true;
+$wgMFAlwaysUseContentProvider = true;

--- a/index.php
+++ b/index.php
@@ -147,6 +147,19 @@ if ( $useOAuth && !$user ) {
 						]
 					),
 					new OOUI\FieldLayout(
+						new OOUI\CheckboxInputWidget( [
+							'name' => 'proxy',
+							'value' => 1,
+							'selected' => false
+						] ),
+						[
+							'label' => 'Proxy articles from en.wikipedia.org',
+							'help' => 'Any articles not local to the wiki will be pulled from English Wikipedia.',
+							'helpInline' => true,
+							'align' => 'left',
+						]
+					),
+					new OOUI\FieldLayout(
 						new OOUI\ButtonInputWidget( [
 							'classes' => [ 'form-submit' ],
 							'label' => 'Create demo',

--- a/new.php
+++ b/new.php
@@ -248,10 +248,18 @@ foreach ( $linkedTasks as $task ) {
 // Choose repositories to enable
 $repos = get_repo_data();
 
+$useProxy = (int)$_POST['proxy'];
+
 if ( $_POST['preset'] === 'custom' ) {
 	$allowedRepos = $_POST['repos'];
 } else {
 	$allowedRepos = get_repo_presets()[ $_POST['preset'] ];
+}
+
+// When proxying, always enable MobileFrontend
+if ( $useProxy ) {
+	// Doesn't matter if this appears twice
+	$allowedRepos[] = 'mediawiki/extensions/MobileFrontend';
 }
 
 foreach ( array_keys( $repos ) as $repo ) {
@@ -338,6 +346,7 @@ set_progress( 90, 'Setting up wiki content...' );
 
 $cmd = make_shell_command( $baseEnv + [
 	'MAINPAGE' => $mainPage,
+	'USE_PROXY' => $useProxy,
 ], __DIR__ . '/new/postinstall.sh' );
 
 $error = shell_echo( $cmd );

--- a/new/postinstall.sh
+++ b/new/postinstall.sh
@@ -32,6 +32,16 @@ do
 	php $PATCHDEMO/wikis/$NAME/w/maintenance/importDump.php < $PATCHDEMO/pages/$page
 done
 
+# Add the proxy if selected
+if [ "${USE_PROXY}" = "1" ]; then
+	cat $PATCHDEMO/LocalSettings-proxy.txt >> $PATCHDEMO/wikis/$NAME/w/LocalSettings.php
+	# Import custom Common.js for fetching CSS from the wiki
+	for page in $(find $PATCHDEMO/pages-proxy -name "*.xml" -not -type d -printf '%P\n')
+	do
+		php $PATCHDEMO/wikis/$NAME/w/maintenance/importDump.php < $PATCHDEMO/pages-proxy/$page
+	done
+fi
+
 # update caches after import
 php $PATCHDEMO/wikis/$NAME/w/maintenance/rebuildrecentchanges.php
 php $PATCHDEMO/wikis/$NAME/w/maintenance/initSiteStats.php

--- a/pages-proxy/Common.js.xml
+++ b/pages-proxy/Common.js.xml
@@ -1,0 +1,57 @@
+<mediawiki xmlns="http://www.mediawiki.org/xml/export-0.11/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.11/ http://www.mediawiki.org/xml/export-0.11.xsd" version="0.11" xml:lang="en">
+  <siteinfo>
+    <sitename>Patch Demo (master)</sitename>
+    <dbname>patchdemo_8d2c74938cbcac4399dfb72f64bc2a53</dbname>
+    <base>http://localhost/patchdemo/wikis/8d2c74938cbcac4399dfb72f64bc2a53/w/index.php/Main_Page</base>
+    <generator>MediaWiki 1.36.0-alpha</generator>
+    <case>first-letter</case>
+    <namespaces>
+      <namespace key="-2" case="first-letter">Media</namespace>
+      <namespace key="-1" case="first-letter">Special</namespace>
+      <namespace key="0" case="first-letter" />
+      <namespace key="1" case="first-letter">Talk</namespace>
+      <namespace key="2" case="first-letter">User</namespace>
+      <namespace key="3" case="first-letter">User talk</namespace>
+      <namespace key="4" case="first-letter">Project</namespace>
+      <namespace key="5" case="first-letter">Project talk</namespace>
+      <namespace key="6" case="first-letter">File</namespace>
+      <namespace key="7" case="first-letter">File talk</namespace>
+      <namespace key="8" case="first-letter">MediaWiki</namespace>
+      <namespace key="9" case="first-letter">MediaWiki talk</namespace>
+      <namespace key="10" case="first-letter">Template</namespace>
+      <namespace key="11" case="first-letter">Template talk</namespace>
+      <namespace key="12" case="first-letter">Help</namespace>
+      <namespace key="13" case="first-letter">Help talk</namespace>
+      <namespace key="14" case="first-letter">Category</namespace>
+      <namespace key="15" case="first-letter">Category talk</namespace>
+      <namespace key="710" case="first-letter">TimedText</namespace>
+      <namespace key="711" case="first-letter">TimedText talk</namespace>
+      <namespace key="828" case="first-letter">Module</namespace>
+      <namespace key="829" case="first-letter">Module talk</namespace>
+      <namespace key="2300" case="first-letter">Gadget</namespace>
+      <namespace key="2301" case="first-letter">Gadget talk</namespace>
+      <namespace key="2302" case="case-sensitive">Gadget definition</namespace>
+      <namespace key="2303" case="case-sensitive">Gadget definition talk</namespace>
+    </namespaces>
+  </siteinfo>
+  <page>
+    <title>MediaWiki:Common.js</title>
+    <ns>8</ns>
+    <id>18</id>
+    <revision>
+      <id>20</id>
+      <timestamp>2021-02-26T20:03:28Z</timestamp>
+      <contributor>
+        <username>Patch Demo</username>
+        <id>1</id>
+      </contributor>
+      <comment>Load CSS from en.wiki</comment>
+      <origin>20</origin>
+      <model>javascript</model>
+      <format>text/javascript</format>
+      <text bytes="270" sha1="8l7i230dl0l5ci0s7isy54kf7bw8aa5" xml:space="preserve">mw.loader.load( 'https://en.wikipedia.org/w/index.php?title=MediaWiki:Common.css&amp;action=raw&amp;ctype=text/css', 'text/css' );
+mw.loader.load( 'https://en.wikipedia.org/w/index.php?title=MediaWiki:' + mw.config.get( 'skin' ) + '.css&amp;action=raw&amp;ctype=text/css', 'text/css' );</text>
+      <sha1>8l7i230dl0l5ci0s7isy54kf7bw8aa5</sha1>
+    </revision>
+  </page>
+</mediawiki>


### PR DESCRIPTION
Untested, but I'd like to add a proxy checkbox for testing languages as part of the desktop improvements project. It's really hard to test these without and I've been having to workaround this by using https://gerrit.wikimedia.org/r/c/mediawiki/extensions/MobileFrontend/+/641808