### PR TITLE
Use a 10 character hash for wiki names

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -174,10 +174,7 @@ summary > .oo-ui-labelElement-label {
 }
 
 .wikis .wiki {
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	max-width: 10em;
+	font-family: monospace, monospace;
 }
 
 .wikis .date {

--- a/delete.php
+++ b/delete.php
@@ -25,7 +25,7 @@ if ( !isset( $_POST['confirm' ] ) ) {
 			( $useOAuth ? '<th>Creator</th>' : '' ) .
 		'</tr>' .
 		'<tr>' .
-			'<td data-label="Wiki" class="wiki"><a href="wikis/' . $wiki . '/w" title="' . $wiki . '">' . $wiki . '</a></td>' .
+			'<td data-label="Wiki" class="wiki"><a href="wikis/' . $wiki . '/w" title="' . $wiki . '">' . substr( $wiki, 0, 10 ) . '</a></td>' .
 			'<td data-label="Patches" class="patches">' . $patches . '</td>' .
 			'<td data-label="Linked tasks" class="linkedTasks">' . $linkedTasks . '</td>' .
 			'<td data-label="Time" class="date">' . date( 'Y-m-d H:i:s', $wikiData[ 'created' ] ) . '</td>' .

--- a/editcounts.php
+++ b/editcounts.php
@@ -63,7 +63,7 @@ foreach ( $short_fields as $field => $fieldMeta ) {
 }
 foreach ( $wikis as $wiki => $data ) {
 	echo '<tr>' .
-		'<td data-label="Wikis"><a href="wikis/' . $wiki . '/w/index.php" title="' . $wiki . '">' . $wiki . '</a></td>';
+		'<td data-label="Wikis" class="wiki"><a href="wikis/' . $wiki . '/w/index.php" title="' . $wiki . '">' . substr( $wiki, 0, 10 ) . '</a></td>';
 
 	foreach ( $short_fields as $field => $fieldMeta ) {
 		echo '<td data-label="' . $fieldMeta['label'] . '">' .

--- a/index.php
+++ b/index.php
@@ -250,7 +250,7 @@ while ( $data = $results->fetch_assoc() ) {
 	}
 
 	$rows .= '<tr class="' . implode( ' ', $classes ) . '">' .
-		'<td data-label="Wiki" class="wiki"><a href="wikis/' . $wiki . '/w" title="' . $wiki . '">' . $wiki . '</a></td>' .
+		'<td data-label="Wiki" class="wiki"><a href="wikis/' . $wiki . '/w" title="' . $wiki . '">' . substr( $wiki, 0, 10 ) . '</a></td>' .
 		'<td data-label="Patches" class="patches">' . $patches . '</td>' .
 		'<td data-label="Linked tasks" class="linkedTasks">' . $linkedTasks . '</td>' .
 		'<td data-label="Time" class="date">' . date( 'Y-m-d H:i:s', $wikiData[ 'created' ] ) . '</td>' .

--- a/new.php
+++ b/new.php
@@ -21,7 +21,7 @@ $branch = trim( $_POST['branch'] );
 $patches = trim( $_POST['patches'] );
 $announce = !empty( $_POST['announce'] );
 
-$namePath = md5( $branch . $patches . time() );
+$namePath = substr( md5( $branch . $patches . time() ), 0, 10 );
 $server = detectProtocol() . '://' . $_SERVER['HTTP_HOST'];
 $serverPath = preg_replace( '`/[^/]*$`', '', $_SERVER['REQUEST_URI'] );
 


### PR DESCRIPTION
This makes URLs and other things a bit cleaner by not
using all 32 characters.

16^10 is still a trillion, so unlikely to cause a collision.

Truncate the display of older hashes so they look consistent.