### PR TITLE
Fix display of marker on <summary> tag

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -83,6 +83,8 @@ form {
 
 summary {
 	cursor: pointer;
+	/* stylelint-disable-next-line declaration-no-important */
+	display: list-item !important;
 }
 
 summary > .oo-ui-labelElement-label {


### PR DESCRIPTION
OOUI sets display to block, when it should be list-item.
