### PR TITLE
Add ProofreadPage to supported extensions

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -34,6 +34,7 @@ mediawiki/extensions/ParserFunctions w/extensions/ParserFunctions
 mediawiki/extensions/PdfHandler w/extensions/PdfHandler
 mediawiki/extensions/Poem w/extensions/Poem
 mediawiki/extensions/Popups w/extensions/Popups
+mediawiki/extensions/ProofreadPage w/extensions/ProofreadPage
 mediawiki/extensions/Renameuser w/extensions/Renameuser
 mediawiki/extensions/ReplaceText w/extensions/ReplaceText
 mediawiki/extensions/Scribunto w/extensions/Scribunto


### PR DESCRIPTION
Doesn't add DjVu support for now, because PDFs should be enough
for current testing requirements.