### PR TITLE
Expand article proxying to other features

### DIFF
--- a/localsettings/feature-proxy.txt
+++ b/localsettings/feature-proxy.txt
@@ -3,3 +3,18 @@
 $wgMFContentProviderClass = "MobileFrontend\\ContentProviders\\MwApiContentProvider";
 $wgMFContentProviderTryLocalContentFirst = true;
 $wgMFAlwaysUseContentProvider = true;
+
+// Enable proxying for Page previews if enabled.
+
+$wgPopupsGateway = 'restbaseHTML';
+$wgPopupsRestGatewayEndpoint = 'https://en.wikipedia.org/api/rest_v1/page/summary/';
+
+// Enable proxying for RelatedArticles if enabled.
+
+$wgRelatedArticlesUseCirrusSearchApiUrl = "https://en.wikipedia.org/w/api.php";
+$wgRelatedArticlesUseCirrusSearch = true;
+$wgRelatedArticlesDescriptionSource = 'wikidata';
+
+// Vector search proxying
+
+$wgVectorSearchHost = 'en.wikipedia.org';


### PR DESCRIPTION
RelatedArticles, Page previews and Vector all have additional configuration
which can be made use of to aid testing against production articles
so let's use them.

This unblocks us testing a few things on the page previews site.