### PR TITLE
Use the new MobileFrontendContentProvider

### DIFF
--- a/localsettings/feature-proxy.txt
+++ b/localsettings/feature-proxy.txt
@@ -1,8 +1,7 @@
 // Allow proxying content from production
 
-$wgMFContentProviderClass = "MobileFrontend\\ContentProviders\\MwApiContentProvider";
+$wgMFContentProviderClass = "MobileFrontendContentProviders\\MwApiContentProvider";
 $wgMFContentProviderTryLocalContentFirst = true;
-$wgMFAlwaysUseContentProvider = true;
 
 // Enable proxying for Page previews if enabled.
 

--- a/new.php
+++ b/new.php
@@ -286,10 +286,11 @@ if ( $_POST['preset'] === 'custom' ) {
 	$allowedRepos = get_repo_presets()[ $_POST['preset'] ];
 }
 
-// When proxying, always enable MobileFrontend
+// When proxying, always enable MobileFrontend and its content provider
 if ( $useProxy ) {
 	// Doesn't matter if this appears twice
 	$allowedRepos[] = 'mediawiki/extensions/MobileFrontend';
+	$allowedRepos[] = 'mediawiki/extensions/MobileFrontendContentProvider';
 }
 
 foreach ( array_keys( $repos ) as $repo ) {

--- a/repositories.txt
+++ b/repositories.txt
@@ -59,6 +59,7 @@ mediawiki/extensions/VisualEditor w/extensions/VisualEditor
 VisualEditor/VisualEditor w/extensions/VisualEditor/lib/ve
 mediawiki/extensions/DiscussionTools w/extensions/DiscussionTools
 mediawiki/extensions/MobileFrontend w/extensions/MobileFrontend
+mediawiki/extensions/MobileFrontendContentProvider w/extensions/MobileFrontendContentProvider
 mediawiki/skins/MinervaNeue w/skins/MinervaNeue
 mediawiki/extensions/WikiLambda w/extensions/WikiLambda
 mediawiki/extensions/Wikisource w/extensions/Wikisource


### PR DESCRIPTION
Add the extension to the list but only enable it if proxy
is set or its added in the dropdown.

Drop configuration variables as these are all the defaults
in the new extension.

Should not be merged until https://gerrit.wikimedia.org/r/c/mediawiki/extensions/MobileFrontend/+/709544
has been merged.