### PR TITLE
Fix test page for Disambiguator extension

### DIFF
--- a/pages/Disambiguator.xml
+++ b/pages/Disambiguator.xml
@@ -1,9 +1,9 @@
 <mediawiki xmlns="http://www.mediawiki.org/xml/export-0.11/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.11/ http://www.mediawiki.org/xml/export-0.11.xsd" version="0.11" xml:lang="en">
   <siteinfo>
-    <sitename>Patch Demo (master)</sitename>
-    <dbname>patchdemo_87597e9210</dbname>
-    <base>https://patchdemo.wmflabs.org/wikis/87597e9210/wiki/Main_Page</base>
-    <generator>MediaWiki 1.37.0-alpha</generator>
+    <sitename>Patch Demo (721368,1)</sitename>
+    <dbname>patchdemo_9191a8d0c5</dbname>
+    <base>https://patchdemo.wmflabs.org/wikis/9191a8d0c5/wiki/Main_Page</base>
+    <generator>MediaWiki 1.38.0-alpha</generator>
     <case>first-letter</case>
     <namespaces>
       <namespace key="-2" case="first-letter">Media</namespace>
@@ -37,38 +37,40 @@
   <page>
     <title>New York</title>
     <ns>0</ns>
-    <id>21</id>
+    <id>14</id>
     <revision>
-      <id>23</id>
-      <timestamp>2021-09-08T22:11:36Z</timestamp>
+      <id>28</id>
+      <parentid>16</parentid>
+      <timestamp>2021-09-15T18:00:03Z</timestamp>
       <contributor>
         <ip>172.16.0.164</ip>
       </contributor>
-      <comment>Created page with "'''New York''' may refer to:  * [[New York City]] * [[New York (state)]] * [[New York (magazine)]] * [[New York Yankees]]"</comment>
-      <origin>23</origin>
+      <origin>28</origin>
       <model>wikitext</model>
       <format>text/x-wiki</format>
-      <text bytes="121" sha1="79o6qg7x8hl5vmm91cntjn5205of43p" xml:space="preserve">'''New York''' may refer to:
+      <text bytes="135" sha1="6nptm1pbcj2gvigu7u143zao68vejcz" xml:space="preserve">'''New York''' may refer to:
 
 * [[New York City]]
 * [[New York (state)]]
 * [[New York (magazine)]]
-* [[New York Yankees]]</text>
-      <sha1>79o6qg7x8hl5vmm91cntjn5205of43p</sha1>
+* [[New York Yankees]]
+
+__DISAMBIG__</text>
+      <sha1>6nptm1pbcj2gvigu7u143zao68vejcz</sha1>
     </revision>
   </page>
   <page>
     <title>New York City</title>
     <ns>0</ns>
-    <id>22</id>
+    <id>15</id>
     <revision>
-      <id>24</id>
+      <id>17</id>
       <timestamp>2021-09-08T22:11:51Z</timestamp>
       <contributor>
         <ip>172.16.0.164</ip>
       </contributor>
       <comment>Created page with "New York City"</comment>
-      <origin>24</origin>
+      <origin>17</origin>
       <model>wikitext</model>
       <format>text/x-wiki</format>
       <text bytes="13" sha1="367tfxsqsrabt5k1a8wz0yxxztd9f5e" xml:space="preserve">New York City</text>
@@ -78,15 +80,15 @@
   <page>
     <title>New York (state)</title>
     <ns>0</ns>
-    <id>23</id>
+    <id>16</id>
     <revision>
-      <id>25</id>
+      <id>18</id>
       <timestamp>2021-09-08T22:12:03Z</timestamp>
       <contributor>
         <ip>172.16.0.164</ip>
       </contributor>
       <comment>Created page with "New York State"</comment>
-      <origin>25</origin>
+      <origin>18</origin>
       <model>wikitext</model>
       <format>text/x-wiki</format>
       <text bytes="14" sha1="i3ae2z04l9gltdmbd3ppipi32n9klgr" xml:space="preserve">New York State</text>
@@ -96,15 +98,15 @@
   <page>
     <title>New York (magazine)</title>
     <ns>0</ns>
-    <id>24</id>
+    <id>17</id>
     <revision>
-      <id>26</id>
+      <id>19</id>
       <timestamp>2021-09-08T22:12:17Z</timestamp>
       <contributor>
         <ip>172.16.0.164</ip>
       </contributor>
       <comment>Created page with "''New York'' magazine"</comment>
-      <origin>26</origin>
+      <origin>19</origin>
       <model>wikitext</model>
       <format>text/x-wiki</format>
       <text bytes="21" sha1="kyskl8ptg3te9k6nvb5vxx2xjx9xqk1" xml:space="preserve">''New York'' magazine</text>
@@ -114,15 +116,15 @@
   <page>
     <title>New York Yankees</title>
     <ns>0</ns>
-    <id>25</id>
+    <id>18</id>
     <revision>
-      <id>27</id>
+      <id>20</id>
       <timestamp>2021-09-08T22:12:30Z</timestamp>
       <contributor>
         <ip>172.16.0.164</ip>
       </contributor>
       <comment>Created page with "New York Yankees"</comment>
-      <origin>27</origin>
+      <origin>20</origin>
       <model>wikitext</model>
       <format>text/x-wiki</format>
       <text bytes="16" sha1="9w24cn3fo300z887yksu8r90qzstacr" xml:space="preserve">New York Yankees</text>


### PR DESCRIPTION
The actual dab page was missing the `__DISAMBIG__` magic word