### PR TITLE
Add RevisionSlider to allowed extensions

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -37,6 +37,7 @@ mediawiki/extensions/Popups w/extensions/Popups
 mediawiki/extensions/ProofreadPage w/extensions/ProofreadPage
 mediawiki/extensions/Renameuser w/extensions/Renameuser
 mediawiki/extensions/ReplaceText w/extensions/ReplaceText
+mediawiki/extensions/RevisionSlider w/extensions/RevisionSlider
 mediawiki/extensions/Scribunto w/extensions/Scribunto
 mediawiki/extensions/SecurePoll w/extensions/SecurePoll
 mediawiki/extensions/SpamBlacklist w/extensions/SpamBlacklist


### PR DESCRIPTION
WMF deployed extension that should be available to test.
Already included in repositories-preset-wikimedia.txt but not actually available in the list of supported extensions.