### PR TITLE
Add MassMessage to allowed extensions

### DIFF
--- a/repository-lists/all.txt
+++ b/repository-lists/all.txt
@@ -25,6 +25,7 @@ mediawiki/extensions/InputBox w/extensions/InputBox
 mediawiki/extensions/Interwiki w/extensions/Interwiki
 mediawiki/extensions/Linter w/extensions/Linter
 mediawiki/extensions/LocalisationUpdate w/extensions/LocalisationUpdate
+mediawiki/extensions/MassMessage w/extensions/MassMessage
 mediawiki/extensions/MultimediaViewer w/extensions/MultimediaViewer
 mediawiki/extensions/Nuke w/extensions/Nuke
 mediawiki/extensions/OATHAuth w/extensions/OATHAuth


### PR DESCRIPTION
WMF deployed extension that should be available to test.
Already included in repository-lists/wikimedia.txt but not actually available in the list of supported extensions.