### PR TITLE
Add the 'Translate' extension

### DIFF
--- a/localsettings/extensions-Translate.txt
+++ b/localsettings/extensions-Translate.txt
@@ -1,0 +1,6 @@
+$wgGroupPermissions['translator']['translate'] = true;
+$wgGroupPermissions['translator']['skipcaptcha'] = true; // Bug 34182: needed with ConfirmEdit
+$wgTranslateDocumentationLanguageCode = 'qqq';
+
+# Add this if you want to enable access to page translation
+$wgGroupPermissions['sysop']['pagetranslation'] = true;

--- a/repository-lists/all.txt
+++ b/repository-lists/all.txt
@@ -51,6 +51,7 @@ mediawiki/extensions/TemplateWizard w/extensions/TemplateWizard
 mediawiki/extensions/TextExtracts w/extensions/TextExtracts
 mediawiki/extensions/TimedMediaHandler w/extensions/TimedMediaHandler
 mediawiki/extensions/TitleBlacklist w/extensions/TitleBlacklist
+mediawiki/extensions/Translate w/extensions/Translate
 mediawiki/extensions/UniversalLanguageSelector w/extensions/UniversalLanguageSelector
 mediawiki/extensions/UploadWizard w/extensions/UploadWizard
 mediawiki/extensions/WikiEditor w/extensions/WikiEditor

--- a/repository-lists/wikimedia.yaml
+++ b/repository-lists/wikimedia.yaml
@@ -96,8 +96,9 @@
 - mediawiki/extensions/timeline
 - mediawiki/extensions/TitleBlacklist
 - mediawiki/extensions/TorBlock
-- mediawiki/extensions/Translate
-- mediawiki/extensions/TranslationNotifications
+# Not installed on most WMF wikis
+# - mediawiki/extensions/Translate
+# - mediawiki/extensions/TranslationNotifications
 - mediawiki/extensions/TrustedXFF
 - mediawiki/extensions/TwoColConflict
 - mediawiki/extensions/UniversalLanguageSelector


### PR DESCRIPTION
Exclude it from the Wikimedia preset as it is not
available on most WMF wikis.

Fixes #320