### PR TITLE
Add Popups to Wikimedia preset

### DIFF
--- a/localsettings/extensions-Popups.txt
+++ b/localsettings/extensions-Popups.txt
@@ -1,0 +1,2 @@
+$wgPopupsReferencePreviews = true;
+$wgPopupsReferencePreviewsBetaFeature = false;

--- a/repository-lists/wikimedia.yaml
+++ b/repository-lists/wikimedia.yaml
@@ -75,6 +75,7 @@
 - mediawiki/extensions/PdfHandler
 - mediawiki/extensions/Poem
 - mediawiki/extensions/PoolCounter
+- mediawiki/extensions/Popups
 - mediawiki/extensions/ReadingLists
 - mediawiki/extensions/Renameuser
 - mediawiki/extensions/RevisionSlider


### PR DESCRIPTION
It is installed on all Wikipedias.

Also add the config used on wiki.
