### PR TITLE
Replace `npm install` with `npm ci` in the setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,7 @@ sudo mysql -u patchdemo --password='patchdemo' < sql/patchdemo.sql
 
 # dependencies for the website
 composer update --no-dev
-npm install --production
+npm ci --production
 
 # setup daily cron job to deduplicate files
 echo "#!/bin/bash


### PR DESCRIPTION
`npm install` will always re-write package-lock.json, even if there
were no changes in package.json, which is very annoying when you're
running significantly different versions of NPM locally and in
production, since their package-lock.json output will differ and so
production will have unstaged changes after the setup.

`npm ci` doesn't do that. I didn't know about it before.
https://docs.npmjs.com/cli/v8/commands/npm-ci