### PR TITLE
Allow users to change $wgLanguageCode

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -139,6 +139,10 @@ summary > .oo-ui-labelElement-label:not( .oo-ui-inline-help ) {
 	font-size: 0.92857143em;
 }
 
+.form-language {
+	max-width: 10em;
+}
+
 @media ( min-width: 721px ) {
 	.enableNotifications {
 		margin-left: 40%;

--- a/index.php
+++ b/index.php
@@ -168,6 +168,19 @@ if ( $useOAuth && !$user ) {
 						]
 					),
 					new OOUI\FieldLayout(
+						new OOUI\TextInputWidget( [
+							'name' => 'language',
+							'value' => 'en',
+							'classes' => [ 'form-language' ]
+						] ),
+						[
+							'label' => 'Language code',
+							'help' => 'Will be used as the content language and default interface language.',
+							'helpInline' => true,
+							'align' => 'left',
+						]
+					),
+					new OOUI\FieldLayout(
 						new OOUI\CheckboxInputWidget( [
 							'name' => 'proxy',
 							'value' => 1,

--- a/index.php
+++ b/index.php
@@ -187,8 +187,8 @@ if ( $useOAuth && !$user ) {
 							'selected' => false
 						] ),
 						[
-							'label' => 'Proxy articles from en.wikipedia.org',
-							'help' => 'Any articles not local to the wiki will be pulled from English Wikipedia.',
+							'label' => 'Proxy articles from wikipedia.org',
+							'help' => 'Any articles not local to the wiki will be pulled from Wikipedia, using the language code above.',
 							'helpInline' => true,
 							'align' => 'left',
 						]

--- a/js/index.js
+++ b/js/index.js
@@ -155,6 +155,9 @@
 
 		reposInput.emit( 'change' );
 
+		var languageInput = OO.ui.infuse( $( '.form-language' ) );
+		languageInput.setValidation( /^[a-z-]{2,}$/ );
+
 		if ( 'Notification' in window ) {
 			var notifField = OO.ui.infuse( document.getElementsByClassName( 'enableNotifications' )[ 0 ] );
 			// Enable placholder widget so field label isn't greyed out

--- a/localsettings/extensions-GrowthExperiments.txt
+++ b/localsettings/extensions-GrowthExperiments.txt
@@ -1,5 +1,5 @@
-$wgGERestbaseUrl = 'https://en.wikipedia.org/api/rest_v1';
-$wgGENewcomerTasksRemoteApiUrl = 'https://en.wikipedia.org/w/api.php';
+$wgGERestbaseUrl = "https://$wgLanguageCode.wikipedia.org/api/rest_v1";
+$wgGENewcomerTasksRemoteApiUrl = "https://$wgLanguageCode.wikipedia.org/w/api.php";
 $wgGENewcomerTasksTopicType = 'ores';
 $wgWelcomeSurveyExperimentalGroups['exp2_target_specialpage']['range'] = '0-9';
 $wgGEHomepageMentorsList = 'Project:GrowthExperiments_mentors';

--- a/localsettings/extensions-PageViewInfo.txt
+++ b/localsettings/extensions-PageViewInfo.txt
@@ -1,1 +1,1 @@
-$wgPageViewInfoWikimediaDomain = 'en.wikipedia.org';
+$wgPageViewInfoWikimediaDomain = "$wgLanguageCode.wikipedia.org";

--- a/localsettings/feature-proxy.txt
+++ b/localsettings/feature-proxy.txt
@@ -2,18 +2,19 @@
 
 $wgMFContentProviderClass = "MobileFrontendContentProviders\\MwApiContentProvider";
 $wgMFContentProviderTryLocalContentFirst = true;
+$wgMFMwApiContentProviderBaseUri = "https://$wgLanguageCode.wikipedia.org/w/api.php";
 
 // Enable proxying for Page previews if enabled.
 
 $wgPopupsGateway = 'restbaseHTML';
-$wgPopupsRestGatewayEndpoint = 'https://en.wikipedia.org/api/rest_v1/page/summary/';
+$wgPopupsRestGatewayEndpoint = "https://$wgLanguageCode.wikipedia.org/api/rest_v1/page/summary/";
 
 // Enable proxying for RelatedArticles if enabled.
 
-$wgRelatedArticlesUseCirrusSearchApiUrl = "https://en.wikipedia.org/w/api.php";
+$wgRelatedArticlesUseCirrusSearchApiUrl = "https://$wgLanguageCode.wikipedia.org/w/api.php";
 $wgRelatedArticlesUseCirrusSearch = true;
 $wgRelatedArticlesDescriptionSource = 'wikidata';
 
 // Vector search proxying
 
-$wgVectorSearchHost = 'en.wikipedia.org';
+$wgVectorSearchHost = "$wgLanguageCode.wikipedia.org";

--- a/new.php
+++ b/new.php
@@ -20,6 +20,7 @@ $startTime = time();
 $branch = trim( $_POST['branch'] );
 $patches = trim( $_POST['patches'] );
 $announce = !empty( $_POST['announce'] );
+$language = trim( $_POST['language'] );
 
 $namePath = substr( md5( $branch . $patches . time() ), 0, 10 );
 $server = detectProtocol() . '://' . $_SERVER['HTTP_HOST'];
@@ -120,6 +121,13 @@ if ( $patches ) {
 	$patches = array_map( 'trim', preg_split( "/\n|\|/", $patches ) );
 } else {
 	$patches = [];
+}
+
+set_progress( 0, 'Checking language code...' );
+
+if ( !preg_match( '/^[a-z-]{2,}$/', $language ) !== false ) {
+	$languageHtml = htmlentities( $language );
+	abandon( "Invalid language code <em>$languageHtml</em>" );
 }
 
 set_progress( 0, 'Querying patch metadata...' );
@@ -352,6 +360,7 @@ $cmd = make_shell_command( $baseEnv + [
 	'WIKINAME' => $wikiName,
 	'SERVER' => $server,
 	'SERVERPATH' => $serverPath,
+	'LANGUAGE' => $language,
 ], __DIR__ . '/new/install.sh' );
 
 $error = shell_echo( $cmd );

--- a/new/install.sh
+++ b/new/install.sh
@@ -15,6 +15,7 @@ php $PATCHDEMO/wikis/$NAME/w/maintenance/install.php \
 "$WIKINAME" "Patch Demo"
 
 # apply our default settings
+echo "\$wgLanguageCode = '$LANGUAGE';" >> $PATCHDEMO/wikis/$NAME/w/LocalSettings.php
 cat $PATCHDEMO/localsettings/core.txt >> $PATCHDEMO/wikis/$NAME/w/LocalSettings.php
 
 # apply extension/skin/service-specific settings

--- a/new/postinstall.sh
+++ b/new/postinstall.sh
@@ -3,7 +3,8 @@ set -ex
 
 # update Main_Page
 sleep 1 # Ensure edit appears after creation in history
-echo "$MAINPAGE" | php $PATCHDEMO/wikis/$NAME/w/maintenance/edit.php "Main_Page"
+MAINPAGETITLE=$( echo 'echo Title::newMainPage()->getDBkey();' | php $PATCHDEMO/wikis/$NAME/w/maintenance/eval.php )
+echo "$MAINPAGE" | php $PATCHDEMO/wikis/$NAME/w/maintenance/edit.php "$MAINPAGETITLE"
 
 # run update script (#166, #244)
 php $PATCHDEMO/wikis/$NAME/w/maintenance/update.php --quick

--- a/pages-proxy/Common.js.xml
+++ b/pages-proxy/Common.js.xml
@@ -45,13 +45,13 @@
         <username>Patch Demo</username>
         <id>1</id>
       </contributor>
-      <comment>Load CSS from en.wiki</comment>
+      <comment>Load CSS from Wikipedia</comment>
       <origin>20</origin>
       <model>javascript</model>
       <format>text/javascript</format>
-      <text bytes="270" sha1="8l7i230dl0l5ci0s7isy54kf7bw8aa5" xml:space="preserve">mw.loader.load( 'https://en.wikipedia.org/w/index.php?title=MediaWiki:Common.css&amp;action=raw&amp;ctype=text/css', 'text/css' );
-mw.loader.load( 'https://en.wikipedia.org/w/index.php?title=MediaWiki:' + mw.config.get( 'skin' ) + '.css&amp;action=raw&amp;ctype=text/css', 'text/css' );</text>
-      <sha1>8l7i230dl0l5ci0s7isy54kf7bw8aa5</sha1>
+      <text bytes="354" sha1="f0oi2nwxzlzgludf5w1hhz3tgxmpkrh" xml:space="preserve">mw.loader.load( 'https://' + mw.config.get( 'wgContentLanguage' ) + '.wikipedia.org/w/index.php?title=MediaWiki:Common.css&amp;action=raw&amp;ctype=text/css', 'text/css' );
+mw.loader.load( 'https://' + mw.config.get( 'wgContentLanguage' ) + '.wikipedia.org/w/index.php?title=MediaWiki:' + mw.config.get( 'skin' ) + '.css&amp;action=raw&amp;ctype=text/css', 'text/css' );</text>
+      <sha1>f0oi2nwxzlzgludf5w1hhz3tgxmpkrh</sha1>
     </revision>
   </page>
 </mediawiki>


### PR DESCRIPTION
Put in some simple validation to limit language codes
to letters and hyphens for security, but don't bother
to check the code is valid.

Fixes #361
