### PR TITLE
Add ElasticSearch service

### DIFF
--- a/localsettings/extensions-CirrusSearch.txt
+++ b/localsettings/extensions-CirrusSearch.txt
@@ -1,0 +1,5 @@
+require_once "$IP/extensions/CirrusSearch/tests/jenkins/FullyFeaturedConfig.php";
+$wgCirrusSearchServers = [ 'localhost' ];
+$wgCirrusSearchWMFExtraFeatures = [
+	'weighted_tags' => [ 'build' => true, 'use' => true ]
+];

--- a/new/postinstall.sh
+++ b/new/postinstall.sh
@@ -38,6 +38,15 @@ if [ -d $PATCHDEMO/wikis/$NAME/w/extensions/SecurePoll ]; then
 	php $PATCHDEMO/wikis/$NAME/w/maintenance/createAndPromote.php "Patch Demo" --force --custom-groups electionadmin
 fi
 
+# CirrusSearch
+if [ -d $PATCHDEMO/wikis/$NAME/w/extensions/CirrusSearch ]; then
+  php $PATCHDEMO/wikis/$NAME/w/maintenance/update.php --quick
+  php $PATCHDEMO/wikis/$NAME/w/extensions/CirrusSearch/maintenance/UpdateSearchIndexConfig.php
+  php $PATCHDEMO/wikis/$NAME/w/extensions/CirrusSearch/maintenance/ForceSearchIndex.php --skipLinks --indexOnSkip
+  php $PATCHDEMO/wikis/$NAME/w/extensions/CirrusSearch/maintenance/ForceSearchIndex.php --skipParse
+  php $PATCHDEMO/wikis/$NAME/w/maintenance/runJobs.php
+fi
+
 # import extension/skin/service-specific XML dumps
 while IFS=' ' read -r repo dir; do
 	filename=$(echo $repo | sed "s/\//-/g" | sed "s/^mediawiki-//")

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,18 @@ sudo apt-get install apache2 default-mysql-server php libapache2-mod-php php-mys
 # dependencies of our system
 sudo apt-get install git composer npm unzip rdfind
 
+# Docker
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+# ElasticSearch
+docker run -d --restart=always \
+  -v elasticdata:/usr/share/elasticsearch/data \
+  -e "discovery.type=single-node" \
+  -e "bootstrap.system_call_filter=false" \
+  -p 9200:9200 \
+  -p 9300:9300 \
+  docker-registry.wikimedia.org/dev/stretch-elasticsearch:0.1.0
+
 # create master copies of repositories
 sudo -u www-data mkdir repositories
 cd repositories


### PR DESCRIPTION
* Install Docker in VM creation
* Run ElasticSearch as a container using the image from
releng/dev-images which has WMF plugins
* Run CirrusSearch setup scripts in postinstall.sh

Periodically cleaning up old search index data is not done in this
patch. It can be done by deleting the volume associated with the
container (since this is considered throwaway data).

It would be nice if runJobs.php ran periodically for the wiki, as that's
needed to process updates to the search index. Ideas welcome on how to
do that.

Fixes #356