### PR TITLE
Main Page title: Ignore PHP warnings in output of eval.php

### DIFF
--- a/localsettings/core.txt
+++ b/localsettings/core.txt
@@ -1,7 +1,8 @@
 // Generic verbose error reporting stuff
+$isCli = PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg';
 error_reporting( -1 );
 ini_set( 'display_startup_errors', 1 );
-ini_set( 'display_errors', 1 );
+ini_set( 'display_errors', $isCli ? 'stderr' : 1 );
 $wgShowSQLErrors = true;
 $wgDebugDumpSql  = true;
 $wgShowDBErrorBacktrace = true;

--- a/new/postinstall.sh
+++ b/new/postinstall.sh
@@ -3,7 +3,7 @@ set -ex
 
 # update Main_Page
 sleep 1 # Ensure edit appears after creation in history
-MAINPAGETITLE=$( echo 'echo Title::newMainPage()->getDBkey();' | php $PATCHDEMO/wikis/$NAME/w/maintenance/eval.php )
+MAINPAGETITLE=$( echo 'echo Title::newMainPage()->getDBkey();' | php $PATCHDEMO/wikis/$NAME/w/maintenance/eval.php 2> /dev/null )
 echo "$MAINPAGE" | php $PATCHDEMO/wikis/$NAME/w/maintenance/edit.php "$MAINPAGETITLE"
 
 # run update script (#166, #244)


### PR DESCRIPTION
Warnings can be produced by maintenance scripts, e.g. when trying to build REL1_30. Ignore these when getting the main page title.