### PR TITLE
Ensure core.php is always loaded first

### DIFF
--- a/new/install.sh
+++ b/new/install.sh
@@ -20,7 +20,13 @@ php $PATCHDEMO/wikis/$NAME/w/maintenance/install.php \
 echo "\$wgLanguageCode = '$LANGUAGE';" >> $PATCHDEMO/wikis/$NAME/w/LocalSettings.php
 
 mkdir $PATCHDEMO/wikis/$NAME/w/settings.d
-echo 'foreach( glob( __DIR__ . "/settings.d/*.php" ) as $conffile ) { include_once $conffile; }' >> $PATCHDEMO/wikis/$NAME/w/LocalSettings.php
+echo '
+// Always load core.php first
+include_once "settings.d/core.php";
+foreach( glob( __DIR__ . "/settings.d/*.php" ) as $conffile ) {
+	include_once $conffile;
+}
+' >> $PATCHDEMO/wikis/$NAME/w/LocalSettings.php
 
 # apply core/extension/skin/service-specific settings
 while IFS=' ' read -r repo dir; do


### PR DESCRIPTION
Currently this works because 'core' comes before
'extension'/'feature' etc. in the alphabet, but
that is a nasty bug waiting to happen.
