### PR TITLE
Don't abandon a wiki if the main page wasn't edited

### DIFF
--- a/new/postinstall.sh
+++ b/new/postinstall.sh
@@ -4,7 +4,7 @@ set -ex
 # update Main_Page
 sleep 1 # Ensure edit appears after creation in history
 MAINPAGETITLE=$( echo 'echo Title::newMainPage()->getDBkey();' | php $PATCHDEMO/wikis/$NAME/w/maintenance/eval.php 2> /dev/null )
-echo "$MAINPAGE" | php $PATCHDEMO/wikis/$NAME/w/maintenance/edit.php "$MAINPAGETITLE"
+echo "$MAINPAGE" | php $PATCHDEMO/wikis/$NAME/w/maintenance/edit.php "$MAINPAGETITLE" || echo "Can't edit main page"
 
 # run update script (#166, #244)
 php $PATCHDEMO/wikis/$NAME/w/maintenance/update.php --quick


### PR DESCRIPTION
Various errors have caused this script to fail, but it
isn't critical, so let the wiki continue to install so
the error can be better debugged.

Part of #385
