### PR TITLE
Add GrowthExperiments to wikimedia group

### DIFF
--- a/repository-lists/wikimedia.yaml
+++ b/repository-lists/wikimedia.yaml
@@ -48,6 +48,7 @@
 - mediawiki/extensions/GlobalUsage
 - mediawiki/extensions/GlobalUserPage
 - mediawiki/extensions/Graph
+- mediawiki/extensions/GrowthExperiments
 - mediawiki/extensions/GuidedTour
 - mediawiki/extensions/ImageMap
 - mediawiki/extensions/InputBox


### PR DESCRIPTION
GrowthExperiments is now on almost all Wikipedias https://phabricator.wikimedia.org/T247507#7405750