### PR TITLE
Revert "Temporarily remove GrowthExperiments from wikimedia.yaml"

### DIFF
--- a/repository-lists/wikimedia.yaml
+++ b/repository-lists/wikimedia.yaml
@@ -48,8 +48,7 @@
 - mediawiki/extensions/GlobalUsage
 - mediawiki/extensions/GlobalUserPage
 - mediawiki/extensions/Graph
-# Temporarily disabled (https://github.com/MatmaRex/patchdemo/issues/408)
-# - mediawiki/extensions/GrowthExperiments
+- mediawiki/extensions/GrowthExperiments
 - mediawiki/extensions/GuidedTour
 - mediawiki/extensions/ImageMap
 - mediawiki/extensions/InputBox


### PR DESCRIPTION
Reverts MatmaRex/patchdemo#411 as fixed upstream by https://gerrit.wikimedia.org/r/c/mediawiki/extensions/GrowthExperiments/+/752711

Part of #408 