### PR TITLE
Support GlobalPreferences extension

### DIFF
--- a/repository-lists/all.txt
+++ b/repository-lists/all.txt
@@ -17,6 +17,7 @@ mediawiki/extensions/EventLogging w/extensions/EventLogging
 mediawiki/extensions/EventStreamConfig w/extensions/EventStreamConfig
 mediawiki/extensions/FlaggedRevs w/extensions/FlaggedRevs
 mediawiki/extensions/Gadgets w/extensions/Gadgets
+mediawiki/extensions/GlobalPreferences w/extensions/GlobalPreferences
 mediawiki/extensions/GlobalWatchlist w/extensions/GlobalWatchlist
 mediawiki/extensions/GrowthExperiments w/extensions/GrowthExperiments
 mediawiki/extensions/GuidedTour w/extensions/GuidedTour


### PR DESCRIPTION
GlobalPreferences is available on most Wikimedia sites, and I have a bunch of patches want to show to the public.

It has code paths for using the database of a local wiki, and it can work without CentralAuth according to my test.