### PR TITLE
Add GlobalBlocking extension

### DIFF
--- a/localsettings/extensions-GlobalBlocking.php
+++ b/localsettings/extensions-GlobalBlocking.php
@@ -1,0 +1,3 @@
+<?php
+
+$wgGlobalBlockingDatabase = $wgDBname;

--- a/repository-lists/all.txt
+++ b/repository-lists/all.txt
@@ -17,6 +17,7 @@ mediawiki/extensions/EventLogging w/extensions/EventLogging
 mediawiki/extensions/EventStreamConfig w/extensions/EventStreamConfig
 mediawiki/extensions/FlaggedRevs w/extensions/FlaggedRevs
 mediawiki/extensions/Gadgets w/extensions/Gadgets
+mediawiki/extensions/GlobalBlocking w/extensions/GlobalBlocking
 mediawiki/extensions/GlobalPreferences w/extensions/GlobalPreferences
 mediawiki/extensions/GlobalWatchlist w/extensions/GlobalWatchlist
 mediawiki/extensions/GrowthExperiments w/extensions/GrowthExperiments


### PR DESCRIPTION
Enables the [GlobalBlocking](https://www.mediawiki.org/wiki/Extension:GlobalBlocking) extension on Patch Demo.

GlobalBlocking is in use in WMF wikis and recently it has started to receive many patches. It'd be great to test them in a test environment before they even reach e.g. the Beta Cluster or Production wikis.