### PR TITLE
Grant globalblocking permissions to sysops

### DIFF
--- a/localsettings/extensions-GlobalBlocking.php
+++ b/localsettings/extensions-GlobalBlocking.php
@@ -1,3 +1,9 @@
 <?php
 
 $wgGlobalBlockingDatabase = $wgDBname;
+
+$wgGroupPermissions['sysop']['globalblock'] = true;
+$wgGroupPermissions['sysop']['globalblock-whitelist'] = true;
+$wgGroupPermissions['sysop']['globalblock-exempt'] = true;
+
+unset( $wgGroupPermissions['steward'] );


### PR DESCRIPTION
Follow-up to https://github.com/MatmaRex/patchdemo/pull/419
Assign to sysops all GlobalBlocking permissions for easier testing, and remove the steward user group as uneeded.