### PR TITLE
Compact repo list

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -146,6 +146,13 @@ summary > .oo-ui-labelElement-label:not( .oo-ui-inline-help ) {
 	column-gap: 2em;
 }
 
+.form-repos .oo-ui-multiselectWidget-group .oo-ui-checkboxMultioptionWidget {
+	/* Avoid rendering issues in Chrome when it tries to display a checkbox across two columns */
+	-webkit-column-break-inside: avoid;
+	page-break-inside: avoid;
+	break-inside: avoid-column;
+}
+
 .form-announce-taskList {
 	font-size: 0.92857143em;
 }

--- a/css/common.css
+++ b/css/common.css
@@ -153,6 +153,10 @@ summary > .oo-ui-labelElement-label:not( .oo-ui-inline-help ) {
 	break-inside: avoid-column;
 }
 
+.form-repos .oo-ui-multiselectWidget-group .oo-ui-checkboxMultioptionWidget .oo-ui-labelElement-label {
+	max-width: 12em;
+}
+
 .form-announce-taskList {
 	font-size: 0.92857143em;
 }

--- a/css/common.css
+++ b/css/common.css
@@ -139,6 +139,13 @@ summary > .oo-ui-labelElement-label:not( .oo-ui-inline-help ) {
 	margin-right: 1em;
 }
 
+.form-repos .oo-ui-multiselectWidget-group {
+	/* stylelint-disable-next-line declaration-property-unit-disallowed-list */
+	font-size: 12px;
+	column-width: 12em;
+	column-gap: 2em;
+}
+
 .form-announce-taskList {
 	font-size: 0.92857143em;
 }

--- a/index.php
+++ b/index.php
@@ -35,7 +35,7 @@ if ( $useOAuth && !$user ) {
 		$repo = htmlspecialchars( $repo );
 		$repoOptions[] = [
 			'data' => $repo,
-			'label' => $repo,
+			'label' => preg_replace( '`^mediawiki/(extensions/)?`', '', $repo ),
 			'disabled' => ( $repo === 'mediawiki/core' ),
 		];
 	}
@@ -150,7 +150,7 @@ if ( $useOAuth && !$user ) {
 							'label' => 'Choose included repos:',
 							'help' => new OOUI\HtmlSnippet( 'If your extension is not listed, please create a <a href="https://github.com/MatmaRex/patchdemo/issues/new">new issue</a>.' ),
 							'helpInline' => true,
-							'align' => 'left',
+							'align' => 'inline',
 							'classes' => [ 'form-repos-field' ],
 						]
 					),


### PR DESCRIPTION
* Use a multi-column layout (4 on desktop)
* Use a smaller font size
* Remove 'mediawiki/' and 'mediawiki/extensions' prefixes
