### PR TITLE
Provide QuickInstantCommons as a (default) option

### DIFF
--- a/index.php
+++ b/index.php
@@ -156,6 +156,7 @@ if ( $useOAuth && !$user ) {
 					),
 					new OOUI\FieldLayout(
 						new OOUI\CheckboxInputWidget( [
+							'classes' => [ 'form-instantCommons' ],
 							'name' => 'instantCommons',
 							'value' => 1,
 							'selected' => true
@@ -163,6 +164,24 @@ if ( $useOAuth && !$user ) {
 						[
 							'label' => 'Load images from Commons',
 							'help' => 'Any images not local to the wiki will be pulled from Wikimedia Commons.',
+							'helpInline' => true,
+							'align' => 'left',
+						]
+					),
+					new OOUI\FieldLayout(
+						new OOUI\DropdownInputWidget( [
+							'classes' => [ 'form-instantCommonsMethod' ],
+							'name' => 'instantCommonsMethod',
+							'options' => [
+								[ 'data' => 'quick', 'label' => 'QuickInstantCommons' ],
+								[ 'data' => 'full', 'label' => 'InstantCommons' ],
+							]
+						] ),
+						[
+							'label' => 'Method for loading images from Commons',
+							'help' => new OOUI\HtmlSnippet(
+								'<a href="https://www.mediawiki.org/wiki/Extension:QuickInstantCommons">QuickInstantCommons</a> is much faster than using full <a href="https://www.mediawiki.org/wiki/InstantCommons">InstantCommons</a> but may lack some advanced image viewing features.'
+							),
 							'helpInline' => true,
 							'align' => 'left',
 						]

--- a/js/index.js
+++ b/js/index.js
@@ -151,6 +151,13 @@
 
 		reposInput.emit( 'change' );
 
+		var instantCommonsCheckbox = OO.ui.infuse( $( '.form-instantCommons' ) );
+		var instantCommonsMethodDropdown = OO.ui.infuse( $( '.form-instantCommonsMethod' ) );
+
+		instantCommonsCheckbox.on( 'change', function ( value ) {
+			instantCommonsMethodDropdown.setDisabled( !value );
+		} );
+
 		var languageInput = OO.ui.infuse( $( '.form-language' ) );
 		languageInput.setValidation( /^[a-z-]{2,}$/ );
 

--- a/localsettings/extensions-GrowthExperiments.php
+++ b/localsettings/extensions-GrowthExperiments.php
@@ -8,6 +8,12 @@ $wgGEHomepageMentorsList = 'Project:GrowthExperiments_mentors';
 $wgGEHelpPanelHelpDeskTitle = 'Project:GrowthExperiments_help_desk';
 
 $growthExperimentsLocalSettings = "$wgExtensionDirectory/GrowthExperiments/tests/selenium/fixtures/GrowthExperiments.LocalSettings.php";
+
 if ( file_exists( $growthExperimentsLocalSettings ) ) {
+	// This test settings file tries to override wgUseInstantCommons. Don't let it or this would break QuickInstantCommons.
+	$originalInstantCommons = $wgUseInstantCommons;
+
 	require_once $growthExperimentsLocalSettings;
+
+	$wgUseInstantCommons = $originalInstantCommons;
 }

--- a/new.php
+++ b/new.php
@@ -314,9 +314,6 @@ foreach ( $linkedTasks as $task ) {
 // Choose repositories to enable
 $repos = get_repo_data();
 
-$useProxy = !empty( $_POST['proxy'] );
-$useInstantCommons = !empty( $_POST['instantCommons' ] );
-
 if ( $_POST['preset'] === 'custom' ) {
 	$allowedRepos = $_POST['repos'];
 } else {
@@ -326,11 +323,19 @@ if ( $_POST['preset'] === 'custom' ) {
 // Always include repos we are trying to patch (#401)
 $allowedRepos = array_merge( $allowedRepos, $usedRepos );
 
+$useProxy = !empty( $_POST['proxy'] );
+$useInstantCommons = !empty( $_POST['instantCommons' ] );
 // When proxying, always enable MobileFrontend and its content provider
 if ( $useProxy ) {
 	// Doesn't matter if this appears twice
 	$allowedRepos[] = 'mediawiki/extensions/MobileFrontend';
 	$allowedRepos[] = 'mediawiki/extensions/MobileFrontendContentProvider';
+}
+if ( $useInstantCommons ) {
+	if ( $_POST['instantCommonsMethod'] === 'quick' ) {
+		$allowedRepos[] = 'mediawiki/extensions/QuickInstantCommons';
+		$useInstantCommons = false;
+	}
 }
 
 foreach ( array_keys( $repos ) as $repo ) {

--- a/repository-lists/all.txt
+++ b/repository-lists/all.txt
@@ -40,6 +40,7 @@ mediawiki/extensions/PdfHandler w/extensions/PdfHandler
 mediawiki/extensions/Poem w/extensions/Poem
 mediawiki/extensions/Popups w/extensions/Popups
 mediawiki/extensions/ProofreadPage w/extensions/ProofreadPage
+mediawiki/extensions/QuickInstantCommons w/extensions/QuickInstantCommons
 mediawiki/extensions/QuickSurveys w/extensions/QuickSurveys
 mediawiki/extensions/RelatedArticles w/extensions/RelatedArticles
 mediawiki/extensions/Renameuser w/extensions/Renameuser


### PR DESCRIPTION
Makes performance much better and supports most the important
features of InstantCommmons.

When selected, $wgInstantCommons is disabled and the extension
is installed instead (per the instructions on MediaWiki).
