### PR TITLE
Build Codex from source if repo is included

### DIFF
--- a/new/postinstall.sh
+++ b/new/postinstall.sh
@@ -32,7 +32,7 @@ done
 # OOUI build
 if [ -d $PATCHDEMO/wikis/$NAME/w/build/ooui ]; then
 	cd $PATCHDEMO/wikis/$NAME/w/build/ooui
-	npm install
+	npm ci
 	npm x grunt build
 	cd $PATCHDEMO
 	# JS & CSS
@@ -52,7 +52,7 @@ fi
 # TODO test
 if [ -d $PATCHDEMO/wikis/$NAME/w/build/codex ]; then
 	cd $PATCHDEMO/wikis/$NAME/w/build/codex
-	npm install
+	npm ci
 	npm run build-all
 	cd $PATCHDEMO
 	cp -r $PATCHDEMO/wikis/$NAME/w/build/codex/packages/codex/dist/* $PATCHDEMO/wikis/$NAME/w/resources/lib/codex/

--- a/new/postinstall.sh
+++ b/new/postinstall.sh
@@ -48,6 +48,17 @@ if [ -d $PATCHDEMO/wikis/$NAME/w/build/ooui ]; then
 	COMPOSER_CACHE_DIR=/dev/null composer require "oojs/oojs-ui @dev" --update-no-dev
 fi
 
+# Codex build
+# TODO test
+if [ -d $PATCHDEMO/wikis/$NAME/w/build/codex ]; then
+	cd $PATCHDEMO/wikis/$NAME/w/build/codex
+	npm install
+	npm run build-all
+	cd $PATCHDEMO
+	cp -r $PATCHDEMO/wikis/$NAME/w/build/codex/packages/codex/dist/* $PATCHDEMO/wikis/$NAME/w/resources/lib/codex/
+	cp -r $PATCHDEMO/wikis/$NAME/w/build/codex/packages/codex-icons/dist/codex-icons.json $PATCHDEMO/wikis/$NAME/w/resources/lib/codex-icons/
+fi
+
 # grant FlaggedRevs editor rights to the default account
 if [ -d $PATCHDEMO/wikis/$NAME/w/extensions/FlaggedRevs ]; then
 	php $PATCHDEMO/wikis/$NAME/w/maintenance/createAndPromote.php "Patch Demo" --force --custom-groups editor

--- a/repository-lists/all.txt
+++ b/repository-lists/all.txt
@@ -79,3 +79,4 @@ mediawiki/extensions/Wikisource w/extensions/Wikisource
 mediawiki/extensions/Wikistories w/extensions/Wikistories
 mediawiki/extensions/Disambiguator w/extensions/Disambiguator
 oojs/ui w/build/ooui
+design/codex w/build/codex

--- a/repository-lists/wikimedia.yaml
+++ b/repository-lists/wikimedia.yaml
@@ -130,6 +130,7 @@
 - mediawiki/skins/Vector
 - mediawiki/services/parsoid
 - VisualEditor/VisualEditor
-# Including OOUI source requires a build which is fairly slow,
+# Including OOUI or Codex source requires a build which is fairly slow,
 # so should only be done if the user explicitly requests it.
 # - oojs/ui
+# - design/codex


### PR DESCRIPTION
Similar to OOUI, except it's JS only, no PHP.

Also add support for 'main' as an alias for the 'master' branch.
Without this, installing Codex fails, because it doesn't have a
branch named 'master'.