### PR TITLE
Add VueTest extension

### DIFF
--- a/repository-lists/all.txt
+++ b/repository-lists/all.txt
@@ -78,5 +78,6 @@ mediawiki/extensions/WikiLambda extensions/WikiLambda
 mediawiki/extensions/Wikisource extensions/Wikisource
 mediawiki/extensions/Wikistories extensions/Wikistories
 mediawiki/extensions/Disambiguator extensions/Disambiguator
+mediawiki/extensions/VueTest extensions/VueTest
 oojs/ui build/ooui
 design/codex build/codex


### PR DESCRIPTION
This extension is not deployed, but it aids in testing Codex in a
MediaWiki environment.