### PR TITLE
Install Node 14 instead of Node 12

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,9 +3,9 @@ sudo apt-get install apache2 default-mysql-server php libapache2-mod-php php-mys
 # dependencies of our system
 sudo apt-get install git composer npm unzip rdfind curl
 
-# Node 12
+# Node 14
 sudo curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
-sudo sh -c "echo deb https://deb.nodesource.com/node_12.x impish main > /etc/apt/sources.list.d/nodesource.list"
+sudo sh -c "echo deb https://deb.nodesource.com/node_14.x impish main > /etc/apt/sources.list.d/nodesource.list"
 sudo apt-get update
 sudo apt-get install nodejs
 # Update NPM


### PR DESCRIPTION
Running "npm run build" in Codex breaks with Node 12, but works with
Node 14.