### PR TITLE
Partially enable Extension:Score

### DIFF
--- a/localsettings/extensions-Score.php
+++ b/localsettings/extensions-Score.php
@@ -1,0 +1,5 @@
+<?php
+
+// Extension:Score can't be run safely without setting up a secure sandbox,
+// but we can still test patches to the VisualEditor UI.
+$wgScoreLilyPond = '/dev/null';

--- a/repository-lists/all.txt
+++ b/repository-lists/all.txt
@@ -48,6 +48,7 @@ mediawiki/extensions/Renameuser extensions/Renameuser
 mediawiki/extensions/ReplaceText extensions/ReplaceText
 mediawiki/extensions/RevisionSlider extensions/RevisionSlider
 mediawiki/extensions/SandboxLink extensions/SandboxLink
+mediawiki/extensions/Score extensions/Score
 mediawiki/extensions/Scribunto extensions/Scribunto
 mediawiki/extensions/SecurePoll extensions/SecurePoll
 mediawiki/extensions/SpamBlacklist extensions/SpamBlacklist

--- a/repository-lists/wikimedia.yaml
+++ b/repository-lists/wikimedia.yaml
@@ -87,7 +87,9 @@
 - mediawiki/extensions/Renameuser
 - mediawiki/extensions/RevisionSlider
 # - mediawiki/extensions/RSS
-- mediawiki/extensions/Score
+# Score is deployed everywhere, but doesn't work fully without a
+# secure sandbox. It is only needed to test the VisualEditor UI.
+# - mediawiki/extensions/Score
 - mediawiki/extensions/Scribunto
 - mediawiki/extensions/SecureLinkFixer
 - mediawiki/extensions/SecurePoll


### PR DESCRIPTION
Ensure we don't try to use LilyPond as it isn't safe
without a secure sandbox, but we can test the VE UI.

Part of #316
