### PR TITLE
Fix `git worktree` creating invalid refs

### DIFF
--- a/new/checkout.sh
+++ b/new/checkout.sh
@@ -2,4 +2,7 @@
 set -ex
 
 git --git-dir=$PATCHDEMO/repositories/$REPO_SOURCE/.git worktree prune
-git --git-dir=$PATCHDEMO/repositories/$REPO_SOURCE/.git worktree add --detach $PATCHDEMO/wikis/$NAME/$REPO_TARGET $BRANCH
+# Canonicalize the path using `readlink -f` to avoid a bug where `git worktree`
+# creates invalid refs when the path ends with '/.' (#446)
+git --git-dir=$PATCHDEMO/repositories/$REPO_SOURCE/.git worktree add \
+	--detach $(readlink -f $PATCHDEMO/wikis/$NAME/$REPO_TARGET) $BRANCH


### PR DESCRIPTION
Fixes #446