### PR TITLE
Create the w/build/ directory in precheckout.sh

### DIFF
--- a/new/precheckout.sh
+++ b/new/precheckout.sh
@@ -3,3 +3,4 @@ set -ex
 
 mkdir $PATCHDEMO/wikis/$NAME
 mkdir $PATCHDEMO/wikis/$NAME/w
+mkdir $PATCHDEMO/wikis/$NAME/build


### PR DESCRIPTION
Without this, the readlink fix for #446 breaks when Codex or OOUI is
included, because it tries to do
readlink -f $PATCHDEMO/wikis/$NAME/build/codex , but the parent
directory doesn't exist.