### PR TITLE
Adding Campaign Events Extension

### DIFF
--- a/repository-lists/all.txt
+++ b/repository-lists/all.txt
@@ -2,6 +2,7 @@ mediawiki/core .
 mediawiki/extensions/3D extensions/3D
 mediawiki/extensions/AbuseFilter extensions/AbuseFilter
 mediawiki/extensions/BetaFeatures extensions/BetaFeatures
+mediawiki/extensions/CampaignEvents extensions/CampaignEvents
 mediawiki/extensions/CategoryTree extensions/CategoryTree
 mediawiki/extensions/CampaignEvents extensions/CampaignEvents
 mediawiki/extensions/CharInsert extensions/CharInsert

--- a/repository-lists/all.txt
+++ b/repository-lists/all.txt
@@ -3,6 +3,7 @@ mediawiki/extensions/3D extensions/3D
 mediawiki/extensions/AbuseFilter extensions/AbuseFilter
 mediawiki/extensions/BetaFeatures extensions/BetaFeatures
 mediawiki/extensions/CategoryTree extensions/CategoryTree
+mediawiki/extensions/CampaignEvents extensions/CampaignEvents
 mediawiki/extensions/CharInsert extensions/CharInsert
 mediawiki/extensions/ChessBrowser extensions/ChessBrowser
 mediawiki/extensions/Cite extensions/Cite

--- a/repository-lists/all.txt
+++ b/repository-lists/all.txt
@@ -4,7 +4,6 @@ mediawiki/extensions/AbuseFilter extensions/AbuseFilter
 mediawiki/extensions/BetaFeatures extensions/BetaFeatures
 mediawiki/extensions/CampaignEvents extensions/CampaignEvents
 mediawiki/extensions/CategoryTree extensions/CategoryTree
-mediawiki/extensions/CategoryTree extensions/CategoryTree
 mediawiki/extensions/CharInsert extensions/CharInsert
 mediawiki/extensions/ChessBrowser extensions/ChessBrowser
 mediawiki/extensions/Cite extensions/Cite

--- a/repository-lists/all.txt
+++ b/repository-lists/all.txt
@@ -4,7 +4,7 @@ mediawiki/extensions/AbuseFilter extensions/AbuseFilter
 mediawiki/extensions/BetaFeatures extensions/BetaFeatures
 mediawiki/extensions/CampaignEvents extensions/CampaignEvents
 mediawiki/extensions/CategoryTree extensions/CategoryTree
-mediawiki/extensions/CampaignEvents extensions/CampaignEvents
+mediawiki/extensions/CategoryTree extensions/CategoryTree
 mediawiki/extensions/CharInsert extensions/CharInsert
 mediawiki/extensions/ChessBrowser extensions/ChessBrowser
 mediawiki/extensions/Cite extensions/Cite


### PR DESCRIPTION
Enables the [CampaignEvents](https://www.mediawiki.org/wiki/Extension:CampaignEvents) extension on Patch Demo.

CampaignEvents extension is being created by the [Campaigns Team](https://meta.wikimedia.org/wiki/Campaigns/Foundation_Product_Team). It'd be great to test it in a test environment before they even reach e.g. the Beta Cluster or Production wikis.