### PR TITLE
checkout.sh: Make sure path exists before readlink'ing it

### DIFF
--- a/new/checkout.sh
+++ b/new/checkout.sh
@@ -2,6 +2,10 @@
 set -ex
 
 git --git-dir=$PATCHDEMO/repositories/$REPO_SOURCE/.git worktree prune
+
+# Make sure the path we're passing in exists, otherwise `readlink -f` will fail
+mkdir -p $PATCHDEMO/wikis/$NAME/$REPO_TARGET
+
 # Canonicalize the path using `readlink -f` to avoid a bug where `git worktree`
 # creates invalid refs when the path ends with '/.' (#446)
 git --git-dir=$PATCHDEMO/repositories/$REPO_SOURCE/.git worktree add \

--- a/new/precheckout.sh
+++ b/new/precheckout.sh
@@ -3,4 +3,3 @@ set -ex
 
 mkdir $PATCHDEMO/wikis/$NAME
 mkdir $PATCHDEMO/wikis/$NAME/w
-mkdir $PATCHDEMO/wikis/$NAME/build


### PR DESCRIPTION
This avoids errors when trying to check things out into /w/build/FOO.
 
Also remove the line in precheckout.sh creating /build. This is the
wrong path, it should be /w/build, but creating that causes errors
because the "git worktree add" command wants an empty directory.