### PR TITLE
enable PageTriage extension

### DIFF
--- a/repository-lists/all.txt
+++ b/repository-lists/all.txt
@@ -38,6 +38,7 @@ mediawiki/extensions/MultimediaViewer extensions/MultimediaViewer
 mediawiki/extensions/Nuke extensions/Nuke
 mediawiki/extensions/OATHAuth extensions/OATHAuth
 mediawiki/extensions/PageImages extensions/PageImages
+mediawiki/extensions/PageTriage extensions/PageTriage
 mediawiki/extensions/PageViewInfo extensions/PageViewInfo
 mediawiki/extensions/ParserFunctions extensions/ParserFunctions
 mediawiki/extensions/PdfHandler extensions/PdfHandler


### PR DESCRIPTION
*Not* adding to wikimedia preset because its a big extension and only used on enwiki