### PR TITLE
Handle OAuth server connection errors

### DIFF
--- a/oauth.php
+++ b/oauth.php
@@ -9,9 +9,21 @@ $user = null;
 
 $useOAuth = !empty( $config[ 'oauth' ][ 'url' ] );
 
+$authUrl = null;
+$authErr = null;
+
 function oauth_signin_prompt() {
-	global $authUrl;
-	return "<div class='signIn'><a href='$authUrl'>Sign in with OAuth</a> to create and manage wikis.</div>";
+	global $authUrl, $authErr;
+	if ( $authErr ) {
+		return "<div class='signIn'>OAuth error:<br>" . htmlentities( $authErr ) . "</div>";
+	} else {
+		return "<div class='signIn'><a href='$authUrl'>Sign in with OAuth</a> to create and manage wikis.</div>";
+	}
+}
+
+function logout() {
+	unset( $_SESSION['access_key'], $_SESSION['access_secret'] );
+	unset( $_SESSION['request_key'], $_SESSION['request_secret'] );
 }
 
 if ( $useOAuth && !$is404 ) {
@@ -23,8 +35,7 @@ if ( $useOAuth && !$is404 ) {
 	$client = new Client( $conf );
 
 	if ( isset( $_GET['logout'] ) ) {
-		unset( $_SESSION['access_key'], $_SESSION['access_secret'] );
-		unset( $_SESSION['request_key'], $_SESSION['request_secret'] );
+		logout();
 	}
 
 	if ( isset( $_GET[ 'oauth_verifier' ] ) && isset( $_SESSION['request_key'] ) ) {
@@ -43,9 +54,18 @@ if ( $useOAuth && !$is404 ) {
 	} else {
 		$client->setCallback( $config[ 'oauth' ][ 'callback' ] );
 
-		list( $authUrl, $token ) = $client->initiate();
+		try {
+			list( $authUrl, $token ) = $client->initiate();
+		} catch ( Exception $e ) {
+			// e.g. Invalid signature error
+			logout();
+			$token = null;
+			$authErr = $e->getMessage();
+		}
 
-		$_SESSION['request_key'] = $token->key;
-		$_SESSION['request_secret'] = $token->secret;
+		if ( $token ) {
+			$_SESSION['request_key'] = $token->key;
+			$_SESSION['request_secret'] = $token->secret;
+		}
 	}
 }


### PR DESCRIPTION
If the server is down or OAuth isn't working, Patch demo
can still run without letting the user log in, instead of
stopping on an uncaught exception.
