### PR TITLE
Phonos: improve example IPA on corpus page

### DIFF
--- a/pages/extensions-Phonos.xml
+++ b/pages/extensions-Phonos.xml
@@ -45,87 +45,87 @@
       <text bytes="3508" sha1="60lcj0j0xism45kiuo959zs7xx2xywl" xml:space="preserve">{| class="wikitable"
 ! Word !! IPA
 |-
-| Xochimilco || {{#phonos: text=Xochimilco | ipa=sotʃiˈmilko | lang=es-MX }}
+| Xochimilco || {{#phonos: text=Xochimilco | ipa=/sotʃiˈmilko/ | lang=es }}
 |-
-| Tenochtitlan || {{#phonos: text=Tenochtitlan | ipa=tenoːt͡ʃˈtit͡ɬan | lang=es-MX }}
+| Tenochtitlan || {{#phonos: text=Tenochtitlan | ipa=/tenoːt͡ʃˈtit͡ɬan/ | lang=es }}
 |-
-| Jhené Aiko || {{#phonos: text=Jhené Aiko | ipa=dʒəˈneɪ ˈaɪkoʊ | lang=en-US }}
+| Jhené Aiko || {{#phonos: text=Jhené Aiko | ipa=/dʒəˈneɪ ˈaɪkoʊ/ | lang=en }}
 |-
-| Albuquerque || {{#phonos: text=Albuquerque | ipa=ˈælbəˌkɜːrki | lang=en-US }}
+| Albuquerque || {{#phonos: text=Albuquerque | ipa=/ˈælbəˌkɜːrki/ | lang=en }}
 |-
-| Hyderabad || {{#phonos: text=Hyderabad | ipa=ˈɦaɪ̯daraːbaːd | lang=en-IN }}
+| Hyderabad || {{#phonos: text=Hyderabad | ipa=/ˈɦaɪ̯daraːbaːd/ | lang=en }}
 |-
-| Hasan Minhaj || {{#phonos: text=Hasan Minhaj | ipa=ˈhʌsən ˈmɪnhɑː(d)ʒ | lang=en-US }}
+| Hasan Minhaj || {{#phonos: text=Hasan Minhaj | ipa=/ˈhʌsən ˈmɪnhɑː(d)ʒ/ | lang=en }}
 |-
-| Parangaricutirimícuaro || {{#phonos: text=Parangaricutirimícuaro | ipa=paɾanɡaɾikutiɾiˈmikwaɾo | lang=es-ES }}
+| Parangaricutirimícuaro || {{#phonos: text=Parangaricutirimícuaro | ipa=/paɾanɡaɾikutiɾiˈmikwaɾo/ | lang=es }}
 |-
-| México || {{#phonos: text=México | ipa=mexiko | lang=es-ES }}
+| México || {{#phonos: text=México | ipa=/mexiko/ | lang=es }}
 |-
-| anticonstitutionnellement || {{#phonos: text=anticonstitutionnellement | ipa=ɑ̃.ti.kɔ̃s.ti.ty.sjɔ.nɛl.mɑ̃ | lang=fr-FR }}
+| anticonstitutionnellement || {{#phonos: text=anticonstitutionnellement | ipa=/ɑ̃.ti.kɔ̃s.ti.ty.sjɔ.nɛl.mɑ̃/ | lang=fr }}
 |-
-| Smørrebrød || {{#phonos: text=Smørrebrød | ipa=ˈsmɶɐ̯ˌpʁœðˀ | lang=is-IS }}
+| Smørrebrød || {{#phonos: text=Smørrebrød | ipa=/ˈsmɶɐ̯ˌpʁœðˀ/ | lang=is }}
 |-
-| sudtle || {{#phonos: text=sudtle | ipa=ˈsʌt(ə)l | lang=en-US }}
+| sudtle || {{#phonos: text=sudtle | ipa=/ˈsʌt(ə)l/ | lang=en }}
 |-
-| Jewellry || {{#phonos: text=Jewellry | ipa=ˈdʒuːəlɹi | lang=en-US }}
+| Jewellry || {{#phonos: text=Jewellry | ipa=/dʒuːəlɹi/ | lang=en }}
 |-
-| hamburger || {{#phonos: text=hamburger | ipa=ˈhæmbɝɡɚ | lang=en-US }}
+| hamburger || {{#phonos: text=hamburger | ipa=/hæmbɝɡɚ/ | lang=en }}
 |-
-| Ibibio || {{#phonos: text=Ibibio | ipa=ɪbɪˈbiːəʊ | lang=ibb }}
+| Ibibio || {{#phonos: text=Ibibio | ipa=/ɪbɪˈbiːəʊ/ | lang=ibb }}
 |-
-| awful || {{#phonos: text=awful | ipa=ˈɔːfɫ̩ | lang=en-US }}
+| awful || {{#phonos: text=awful | ipa=/ˈɔːfɫ̩/ | lang=en }}
 |-
-| fly || {{#phonos: text=fly | ipa=flaɪ̯ | lang=en-US }}
+| fly || {{#phonos: text=fly | ipa=/flaɪ̯/ | lang=en }}
 |-
-| catnip || {{#phonos: text=catnip | ipa=ˈkætⁿnɪp | lang=en-US }}
+| catnip || {{#phonos: text=catnip | ipa=/ˈkætⁿnɪp/ | lang=en }}
 |-
-| apt || {{#phonos: text=apt | ipa=ˈæp̚t | lang=en-US }}
+| apt || {{#phonos: text=apt | ipa=/ˈæp̚t/ | lang=en }}
 |-
-| spotless || {{#phonos: text=spotless | ipa=ˈspɒtˡlɨs | lang=en-US }}
+| spotless || {{#phonos: text=spotless | ipa=/ˈspɒtˡlɨs/ | lang=en }}
 |-
-| peculiar || {{#phonos: text=peculiar | ipa=pʰə̥ˈkj̊uːliɚ | lang=en-US }}
+| peculiar || {{#phonos: text=peculiar | ipa=/pʰə̥ˈkj̊uːliɚ/ | lang=en }}
 |-
-| confusion || {{#phonos: text=confusion | ipa=kənˈfjuːʒən | lang=en-US }}
+| confusion || {{#phonos: text=confusion | ipa=/kənˈfjuːʒən/ | lang=en }}
 |-
-| thing || {{#phonos: text=thing | ipa=θɪŋ | lang=en-US }}
+| thing || {{#phonos: text=thing | ipa=/θɪŋ/ | lang=en }}
 |-
-| key || {{#phonos: text=key | ipa=k̟ʰi | lang=en-US }}
+| key || {{#phonos: text=key | ipa=/k̟ʰi/ | lang=en }}
 |-
-| vin blanc || {{#phonos: text=vin blanc | ipa=vɛ̃ blɑ̃ | lang=fr-FR }}
+| vin blanc || {{#phonos: text=vin blanc | ipa=/vɛ̃ blɑ̃/ | lang=fr }}
 |-
-| wean || {{#phonos: text=wean | ipa=ˈwɪən | lang=sco }}
+| wean || {{#phonos: text=wean | ipa=/ˈwɪən/ | lang=sco }}
 |-
-| llandudno || {{#phonos: text=llandudno | ipa=ɬanˈdɨdnoː | lang=cy-GB }}
+| llandudno || {{#phonos: text=llandudno | ipa=/ɬanˈdɨdnoː/ | lang=cy }}
 |-
-| नमस्ते || {{#phonos: text=नमस्ते | ipa=nə.məs.t̪eː | lang=hi-IN }}
+| नमस्ते || {{#phonos: text=नमस्ते | ipa=/nə.məs.t̪eː/ | lang=hi }}
 |-
-| நன்றி || {{#phonos: text=நன்றி | ipa=n̪anri | lang=ta }}
+| நன்றி || {{#phonos: text=நன்றி | ipa=/n̪anri/ | lang=ta }}
 |-
-| Montréal || {{#phonos: text=Montréal | ipa=mɔ̃.ʁe.al | lang=fr-FR }}
+| Montréal || {{#phonos: text=Montréal | ipa=/mɔ̃.ʁe.al/ | lang=fr }}
 |-
-| Louisville || {{#phonos: text=Louisville | ipa=ˈlʊvɪl | lang=en-US }}
+| Louisville || {{#phonos: text=Louisville | ipa=/ˈlʊvɪl/ | lang=en }}
 |-
-| Shibboleth || {{#phonos: text=Shibboleth | ipa=ˈʃɪbəlɛθ | lang=en-US }}
+| Shibboleth || {{#phonos: text=Shibboleth | ipa=/ˈʃɪbəlɛθ/ | lang=en }}
 |-
-| ευχαριστώ || {{#phonos: text=ευχαριστώ | ipa=ef.xa.ɾiˈsto | lang=el }}
+| ευχαριστώ || {{#phonos: text=ευχαριστώ | ipa=/ef.xa.ɾiˈsto/ | lang=el }}
 |-
-| chocolate || {{#phonos: text=chocolate | ipa=ˈt͡ʃɔk(ə)lɪt | lang=en-US }}
+| chocolate || {{#phonos: text=chocolate | ipa=/ˈt͡ʃɔk(ə)lɪt/ | lang=en }}
 |-
-| sushi || {{#phonos: text=sushi | ipa=ˈsʊʃi | lang=en-US }}
+| sushi || {{#phonos: text=sushi | ipa=/ˈsʊʃi/ | lang=en }}
 |-
-| спасибо || {{#phonos: text=спасибо | ipa=spɐˈsʲibə | lang=ru-RU }}
+| спасибо || {{#phonos: text=спасибо | ipa=/spɐˈsʲibə/ | lang=ru }}
 |-
-| supercalifragilisticexpialidocious || {{#phonos: text=supercalifragilisticexpialidocious | ipa=suːpəˌkælɨˌfɹædʒɨˌlɪstɪkˌɛkspɪˌælɨˈdəʊʃəs | lang=en-US }}
+| supercalifragilisticexpialidocious || {{#phonos: text=supercalifragilisticexpialidocious | ipa=/suːpəˌkælɨˌfɹædʒɨˌlɪstɪkˌɛkspɪˌælɨˈdəʊʃəs/ | lang=en }}
 |-
-| Cornwall || {{#phonos: text=Cornwall | ipa=ˈkɔːrnwɔːl | lang=en-US }}
+| Cornwall || {{#phonos: text=Cornwall | ipa=/ˈkɔːrnwɔːl/ | lang=en }}
 |-
-| Thames || {{#phonos: text=Thames | ipa=tɛmz | lang=en-US }}
+| Thames || {{#phonos: text=Thames | ipa=/tɛmz/ | lang=en }}
 |-
-| Gunwalloe || {{#phonos: text=Gunwalloe | ipa=gʌnˈwɒləʊ | lang=en-US }}
+| Gunwalloe || {{#phonos: text=Gunwalloe | ipa=/gʌnˈwɒləʊ/ | lang=en }}
 |-
-| Porthleven || {{#phonos: text=Porthleven | ipa=ˌpɔːrθˈlɛvən | lang=en-US }}
+| Porthleven || {{#phonos: text=Porthleven | ipa=/ˌpɔːrθˈlɛvən/ | lang=en }}
 |-
-| Somerset || {{#phonos: text=Somerset | ipa=ˈsʌmərsɛt | lang=en-US }}
+| Somerset || {{#phonos: text=Somerset | ipa=/ˈsʌmərsɛt/ | lang=en }}
 |}</text>
       <sha1>60lcj0j0xism45kiuo959zs7xx2xywl</sha1>
     </revision>


### PR DESCRIPTION
Larynx usually wants the slashes, so here we always include them.

We also only use 2-letter language codes because Larynx is limited in what it can interpret.

Some examples still don't work, especially those for unsupported languages, but this is enough for product/design to make use of Phonos on Patch Demo.