### PR TITLE
Apply patches before running installer

### DIFF
--- a/new.php
+++ b/new.php
@@ -512,7 +512,22 @@ foreach ( $composerInstallRepos as $i => $repo ) {
 	$repoProgress += ( $end - $start ) / $repoCount;
 }
 
-set_progress( 65, 'Installing your wiki...' );
+$start = 65;
+$end = 75;
+$progress = $start;
+$count = count( $commands );
+foreach ( $commands as $i => $command ) {
+	$n = $i + 1;
+	set_progress( $progress, "Fetching and applying patches ($n/$count)..." );
+	check_connection();
+	$error = shell_echo( $command[1], $baseEnv + $command[0] );
+	if ( $error ) {
+		abandon( "Could not apply patch {$patchesApplied[$i]}" );
+	}
+	$progress += ( $end - $start ) / $count;
+}
+
+set_progress( 75, 'Installing your wiki...' );
 
 check_connection();
 $error = shell_echo( __DIR__ . '/new/install.sh',
@@ -526,21 +541,6 @@ $error = shell_echo( __DIR__ . '/new/install.sh',
 );
 if ( $error ) {
 	abandon( "Could not install wiki" );
-}
-
-$start = 80;
-$end = 90;
-$progress = $start;
-$count = count( $commands );
-foreach ( $commands as $i => $command ) {
-	$n = $i + 1;
-	set_progress( $progress, "Fetching and applying patches ($n/$count)..." );
-	check_connection();
-	$error = shell_echo( $command[1], $baseEnv + $command[0] );
-	if ( $error ) {
-		abandon( "Could not apply patch {$patchesApplied[$i]}" );
-	}
-	$progress += ( $end - $start ) / $count;
 }
 
 set_progress( 90, 'Setting up wiki content...' );


### PR DESCRIPTION
Patches could affect the outcome of the installation
process, e.g. changing extension.json dependencies.
