### PR TITLE
Enable MediaSearch extension

### DIFF
--- a/localsettings/extensions-MediaSearch.php
+++ b/localsettings/extensions-MediaSearch.php
@@ -1,0 +1,7 @@
+<?php
+
+// External search results API
+$wgMediaSearchExternalSearchUri = 'https://commons.wikimedia.org/w/api.php';
+
+// External entity search base URI (for autocomplete suggestions)
+$wgMediaSearchExternalEntitySearchBaseUri = 'https://www.wikidata.org/w/api.php';

--- a/repository-lists/all.txt
+++ b/repository-lists/all.txt
@@ -37,6 +37,7 @@ mediawiki/extensions/Linter extensions/Linter
 mediawiki/extensions/LocalisationUpdate extensions/LocalisationUpdate
 mediawiki/extensions/Math extensions/Math
 mediawiki/extensions/MassMessage extensions/MassMessage
+mediawiki/extensions/MediaSearch extensions/MediaSearch
 mediawiki/extensions/MultimediaViewer extensions/MultimediaViewer
 mediawiki/extensions/Nuke extensions/Nuke
 mediawiki/extensions/OATHAuth extensions/OATHAuth


### PR DESCRIPTION
Not enabled by default because this is only installed on Commons.

Configure to use external API results from Commons and WikiData,
per on-wiki instructions.

Fixes #487
