### PR TITLE
Fix layout of form on mobile

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -283,6 +283,10 @@ summary > .oo-ui-labelElement-label:not( .oo-ui-inline-help ) {
 }
 
 @media ( max-width: 720px ) {
+	.oo-ui-fieldLayout-align-left > .oo-ui-fieldLayout-body {
+		flex-wrap: wrap;
+	}
+
 	.oo-ui-fieldLayout-align-left > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header,
 	.oo-ui-fieldLayout-align-left > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-field {
 		/* stylelint-disable-next-line declaration-no-important */


### PR DESCRIPTION
OOUI moved to flexbox, so we need to enable flex-wrap.
