### PR TITLE
Add system dependency on lame MP3 encoder for Phonos extension

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,5 @@
 # dependencies of MediaWiki
-sudo apt-get install apache2 default-mysql-server php libapache2-mod-php php-mysql php-intl php-xml php-mbstring php-curl php-wikidiff2 imagemagick librsvg2-bin
+sudo apt-get install apache2 default-mysql-server php libapache2-mod-php php-mysql php-intl php-xml php-mbstring php-curl php-wikidiff2 imagemagick librsvg2-bin lame
 # dependencies of our system
 sudo apt-get install git composer npm unzip rdfind curl
 


### PR DESCRIPTION
Without this, the Phonos test page was timing out on import
and causing wiki creation to fail.
