### PR TITLE
new.php: Fix link to Codex docs site

### DIFF
--- a/new.php
+++ b/new.php
@@ -577,7 +577,7 @@ if ( $announce && count( $linkedTasks ) ) {
 				"\n\n" .
 				"Also created a **Codex documentation** site:" .
 				"\n" .
-				"$server$serverPath/wikis/$wiki/w/build/codex/demos"
+				"$server$serverPath/wikis/$wiki/w/build/codex/docs"
 				: ""
 			)
 		);


### PR DESCRIPTION
This link was correct everywhere else (e.g. on the generated Main Page content), but the link posted to Phabricator was wrong.