### PR TITLE
Proxy feature: Use new $wgVectorSearchApiUrl setting

### DIFF
--- a/localsettings/feature-proxy.php
+++ b/localsettings/feature-proxy.php
@@ -19,4 +19,4 @@ $wgRelatedArticlesDescriptionSource = 'wikidata';
 
 // Vector search proxying
 
-$wgVectorSearchHost = "$wgLanguageCode.wikipedia.org";
+$wgVectorSearchApiUrl = "https://$wgLanguageCode.wikipedia.org/w/rest.php";


### PR DESCRIPTION
Introduced by https://gerrit.wikimedia.org/r/c/mediawiki/skins/Vector/+/838943. Normally we'd try for backwards compatibility here, but the old setting was broken anyway, so that's not needed.