### PR TITLE
Add ConfirmEdit to 'minimal' preset

### DIFF
--- a/includes.php
+++ b/includes.php
@@ -499,9 +499,7 @@ function get_repo_presets(): array {
 
 	$presets['wikimedia'] = Yaml::parse( file_get_contents( __DIR__ . '/repository-lists/wikimedia.yaml' ) );
 	$presets['tarball'] = Yaml::parse( file_get_contents( __DIR__ . '/repository-lists/tarball.yaml' ) );
-
-	// Things don't work well without the default skin
-	$presets['minimal'] = [ 'mediawiki/core', 'mediawiki/skins/Vector' ];
+	$presets['minimal'] = Yaml::parse( file_get_contents( __DIR__ . '/repository-lists/minimal.yaml' ) );
 
 	return $presets;
 }

--- a/index.php
+++ b/index.php
@@ -129,7 +129,7 @@ if ( !$canCreate ) {
 								],
 								[
 									'data' => 'minimal',
-									'label' => new OOUI\HtmlSnippet( '<abbr title="Only MediaWiki and default skin">Minimal</abbr>' ),
+									'label' => new OOUI\HtmlSnippet( '<abbr title="Only MediaWiki and default skin with anti-spam configuration">Minimal</abbr>' ),
 								],
 								[
 									'data' => 'custom',

--- a/repository-lists/minimal.yaml
+++ b/repository-lists/minimal.yaml
@@ -1,0 +1,5 @@
+- mediawiki/core
+# Things don't work well without the default skin
+- mediawiki/skins/Vector
+# Unintrusive anti-spam CAPTCHA
+- mediawiki/extensions/ConfirmEdit


### PR DESCRIPTION
It's too easy to accidentally create a wiki that is open to spam bots.