### PR TITLE
Add AntiSpoof extension

### DIFF
--- a/repository-lists/all.txt
+++ b/repository-lists/all.txt
@@ -1,6 +1,7 @@
 mediawiki/core .
 mediawiki/extensions/3D extensions/3D
 mediawiki/extensions/AbuseFilter extensions/AbuseFilter
+mediawiki/extensions/AntiSpoof extensions/AntiSpoof
 mediawiki/extensions/BetaFeatures extensions/BetaFeatures
 mediawiki/extensions/CampaignEvents extensions/CampaignEvents
 mediawiki/extensions/CategoryTree extensions/CategoryTree

--- a/repository-lists/composerinstall.yaml
+++ b/repository-lists/composerinstall.yaml
@@ -2,6 +2,7 @@
 - mediawiki/core
 - mediawiki/services/parsoid
 - mediawiki/extensions/AbuseFilter
+- mediawiki/extensions/AntiSpoof
 - mediawiki/extensions/CheckUser
 - mediawiki/extensions/Flow
 - mediawiki/extensions/TemplateStyles


### PR DESCRIPTION
There is a maintenance script to add existing users, but I guess they won't exist before the extension is installed