### PR TITLE
Add some configuration need for Kartographer

### DIFF
--- a/localsettings/extensions-Kartographer.php
+++ b/localsettings/extensions-Kartographer.php
@@ -2,3 +2,19 @@
 
 $wgKartographerMapServer = 'https://kartotherian.wmflabs.org';
 $wgKartographerStaticMapframe = true;
+
+// Copied from https://www.mediawiki.org/wiki/Extension:JsonConfig#Supporting_Wikimedia_templates
+$wgJsonConfigEnableLuaSupport = true;
+$wgJsonConfigModels['Map.JsonConfig'] = 'JsonConfig\JCMapDataContent';
+$wgJsonConfigs['Map.JsonConfig'] = [
+	'namespace' => 486,
+	'nsName' => 'Data',
+	// page name must end in ".map", and contain at least one symbol
+	'pattern' => '/.\.map$/',
+	'license' => 'CC0-1.0',
+	'isLocal' => false,
+];
+$wgJsonConfigInterwikiPrefix = "commons";
+$wgJsonConfigs['Map.JsonConfig']['remote'] = [
+	'url' => 'https://commons.wikimedia.org/w/api.php'
+];


### PR DESCRIPTION
I get the following error when trying to use patchdemo for Kartographer:

A dependency error was encountered while installing the extension "Kartographer": Could not find the registration file for the extension "JsonConfig";

I'm not very much into what's going on there, but in our dev env we use the lines I added here as a default for the Kartographer set.