### PR TITLE
api.php: add CORS header

### DIFF
--- a/api.php
+++ b/api.php
@@ -3,6 +3,7 @@
 require_once "includes.php";
 
 header( 'Content-Type: application/json' );
+header( 'Access-Control-Allow-Origin: *' );
 
 $data = null;
 


### PR DESCRIPTION
We need the API to emit `Access-Control-Allow-Origin: *` to allow downstream usage in JavaScript application. For example the integration with https://gerrit.wikimedia.org/. Without it, the browser complains with:

Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at
https://patchdemo.wmflabs.org/api.php?action=findwikis&change=922162. (Reason: CORS header ‘Access-Control-Allow-Origin’ missing).

Part of #285
Follow-up #537

Bug: https://phabricator.wikimedia.org/T332474