### PR TITLE
composerinstall.yaml: add UrlShortener

### DIFF
--- a/repository-lists/composerinstall.yaml
+++ b/repository-lists/composerinstall.yaml
@@ -7,3 +7,4 @@
 - mediawiki/extensions/Flow
 - mediawiki/extensions/TemplateStyles
 - mediawiki/extensions/IPInfo
+- mediawiki/extensions/UrlShortener


### PR DESCRIPTION
UrlShortener will soon have composer dependencies, i.e. https://gerrit.wikimedia.org/r/c/mediawiki/extensions/UrlShortener/+/930716