### PR TITLE
Ignore dependencies on Wikimedia config repositories

### DIFF
--- a/includes.php
+++ b/includes.php
@@ -553,6 +553,10 @@ function get_repo_presets(): array {
 	return $presets;
 }
 
+function get_ignored_repos(): array {
+	return Yaml::parse( file_get_contents( __DIR__ . '/repository-lists/ignored.yaml' ) );
+}
+
 function get_known_pages(): array {
 	$pages = [
 		'Main Page'

--- a/repository-lists/ignored.yaml
+++ b/repository-lists/ignored.yaml
@@ -1,0 +1,5 @@
+# Wikimedia config repositories that are sometimes listed in 'Depends-On',
+# but which we don't support (and don't need to support to test patches)
+- mediawiki/vendor
+- integration/config
+- operations/mediawiki-config


### PR DESCRIPTION
Sometimes folks point 'Depends-On' entries to Wikimedia config repositories. We don't support them, but these dependencies are usually not needed to test a patch on Patch demo, so ignore them instead of erroring out.

Closes #573